### PR TITLE
fix: add Podman support with NVIDIA CDI GPU passthrough

### DIFF
--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -2,7 +2,9 @@
 # Everything runs on your machine: LLM, STT, TTS, embeddings, memory.
 # No API keys, no cloud accounts, no data leaving your network.
 #
-# GPU: Uncomment the 'deploy' section under ollama for NVIDIA acceleration.
+# GPU: Uncomment ONE of the GPU sections under ollama:
+#   - Docker:  the 'deploy' block (uses nvidia container runtime)
+#   - Podman:  the 'devices' line (uses CDI — requires nvidia-ctk cdi generate)
 #
 # Usage:
 #   docker compose up -d
@@ -31,13 +33,13 @@ services:
     restart: unless-stopped
 
   redis:
-    image: redis:alpine
+    image: docker.io/library/redis:alpine
     volumes:
       - redis_data:/data
     restart: unless-stopped
 
   postgres:
-    image: pgvector/pgvector:pg17
+    image: docker.io/pgvector/pgvector:pg17
     environment:
       POSTGRES_USER: magec
       POSTGRES_PASSWORD: magec
@@ -47,11 +49,13 @@ services:
     restart: unless-stopped
 
   ollama:
-    image: ollama/ollama:latest
+    image: docker.io/ollama/ollama:latest
     volumes:
       - ollama_data:/root/.ollama
     restart: unless-stopped
-    # Uncomment for NVIDIA GPU acceleration:
+    # ── NVIDIA GPU acceleration (uncomment ONE option) ──────────────
+    #
+    # Option A — Docker (nvidia-container-runtime):
     # deploy:
     #   resources:
     #     reservations:
@@ -59,9 +63,13 @@ services:
     #         - driver: nvidia
     #           count: all
     #           capabilities: [gpu]
+    #
+    # Option B — Podman (CDI — run: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml):
+    # devices:
+    #   - nvidia.com/gpu=all
 
   ollama-setup:
-    image: ollama/ollama:latest
+    image: docker.io/ollama/ollama:latest
     depends_on:
       - ollama
     restart: "no"
@@ -87,7 +95,7 @@ services:
     restart: unless-stopped
 
   tts:
-    image: travisvn/openai-edge-tts:latest
+    image: docker.io/travisvn/openai-edge-tts:latest
     environment:
       - REQUIRE_API_KEY=False
     restart: unless-stopped


### PR DESCRIPTION
## Problem

The project assumes Docker as the only container engine. Podman users hit two issues:

1. **GPU passthrough fails** — The `deploy.resources.reservations.devices` syntax is Docker-specific. Podman uses [CDI (Container Device Interface)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html) instead.
2. **Image pulls hang or fail** — Short image names like `redis:alpine` or `ollama/ollama` trigger Podman's interactive registry prompt (or fail in non-interactive mode), since Podman doesn't default to `docker.io`.

## Changes

**`docker-compose.yaml`**
- Document both GPU options: Docker (`deploy` block) and Podman (`devices: nvidia.com/gpu=all`)
- Fully qualify all Docker Hub images with `docker.io/` prefix

**`scripts/install.sh`**
- Auto-detect Podman or Docker at install time
- Handle `podman compose` and `podman-compose` as compose backends
- Validate NVIDIA GPU via CDI specs when running under Podman
- Generate the correct GPU syntax in the compose file based on the detected engine
- Fully qualify all Docker Hub image references

**`Makefile`**
- Add `CONTAINER_ENGINE` variable (auto-detects `podman`, falls back to `docker`)
- Fully qualify image references

## Notes

- No behavioral change for Docker users — all defaults remain the same
- Podman GPU requires the NVIDIA Container Toolkit with CDI specs generated:
  ```
  sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
  ```
