### PR TITLE
Feat/switch clients to sse

### DIFF
--- a/frontend/admin-ui/src/style.css
+++ b/frontend/admin-ui/src/style.css
@@ -71,6 +71,17 @@ dialog::backdrop {
   opacity: 0;
 }
 
+input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 * {
   scrollbar-width: thin;
   scrollbar-color: #3d3d44 transparent;

--- a/frontend/admin-ui/src/views/agents/AgentDetail.vue
+++ b/frontend/admin-ui/src/views/agents/AgentDetail.vue
@@ -76,7 +76,12 @@ const contextGuardSummary = computed(() => {
   if (!cg?.enabled) return 'Disabled'
   const labels = { threshold: 'Token threshold', sliding_window: 'Sliding window' }
   const strategy = labels[cg.strategy] || cg.strategy || 'Token threshold'
-  const detail = cg.strategy === 'sliding_window' && cg.maxTurns ? `${strategy} (${cg.maxTurns} turns)` : strategy
+  let detail = strategy
+  if (cg.strategy === 'sliding_window' && cg.maxTurns) {
+    detail = `${strategy} (${cg.maxTurns} turns)`
+  } else if (cg.strategy === 'threshold' && cg.maxTokens) {
+    detail = `${strategy} (${cg.maxTokens.toLocaleString()} tokens)`
+  }
   return `${detail} (experimental)`
 })
 

--- a/frontend/admin-ui/src/views/agents/AgentDialog.vue
+++ b/frontend/admin-ui/src/views/agents/AgentDialog.vue
@@ -83,6 +83,11 @@
                 <FormInput v-model="form.contextGuardMaxTurns" type="number" placeholder="20" />
                 <p class="text-[10px] text-arena-500 mt-1">Number of messages to keep before summarizing older ones</p>
               </div>
+              <div v-if="form.contextGuardStrategy === 'threshold'">
+                <FormLabel label="Max tokens" />
+                <FormInput v-model="form.contextGuardMaxTokens" type="number" placeholder="Auto (model limit)" />
+                <p class="text-[10px] text-arena-500 mt-1">Token limit for triggering summarization. Leave empty to auto-detect from model.</p>
+              </div>
             </div>
           </div>
         </div>
@@ -241,6 +246,7 @@ const form = reactive({
   contextGuardEnabled: false,
   contextGuardStrategy: 'threshold',
   contextGuardMaxTurns: '',
+  contextGuardMaxTokens: '',
   a2aEnabled: false,
 })
 
@@ -289,6 +295,7 @@ function open(agent = null) {
   form.contextGuardEnabled = agent?.contextGuard?.enabled || false
   form.contextGuardStrategy = agent?.contextGuard?.strategy || 'threshold'
   form.contextGuardMaxTurns = agent?.contextGuard?.maxTurns || ''
+  form.contextGuardMaxTokens = agent?.contextGuard?.maxTokens || ''
   form.a2aEnabled = agent?.a2a?.enabled || false
   dialogRef.value?.open()
 }
@@ -314,6 +321,7 @@ async function save() {
       enabled: true,
       strategy: form.contextGuardStrategy,
       maxTurns: parseInt(form.contextGuardMaxTurns) || 0,
+      maxTokens: parseInt(form.contextGuardMaxTokens) || 0,
     } : undefined,
     a2a: form.a2aEnabled ? { enabled: true } : undefined,
   }

--- a/server/agent/agent.go
+++ b/server/agent/agent.go
@@ -250,7 +250,7 @@ func New(ctx context.Context, agents []store.AgentDefinition, backends []store.B
 	}
 
 	return &Service{
-		handler:    adkrest.NewHandler(launcherCfg, 30*time.Second),
+		handler:    adkrest.NewHandler(launcherCfg, 15*time.Minute),
 		sessionSvc: sessionSvc,
 		memorySvc:  memorySvc,
 		adkAgents:  adkAgentMap,

--- a/server/agent/agent.go
+++ b/server/agent/agent.go
@@ -225,6 +225,7 @@ func New(ctx context.Context, agents []store.AgentDefinition, backends []store.B
 	if cwRegistry != nil {
 		strategies := make(map[string]string)
 		maxTurns := make(map[string]int)
+		maxTokens := make(map[string]int)
 		guardLLMs := make(map[string]model.LLM)
 		for _, agentDef := range agents {
 			cg := agentDef.ContextGuard
@@ -240,12 +241,16 @@ func New(ctx context.Context, agents []store.AgentDefinition, backends []store.B
 			if cg.MaxTurns > 0 {
 				maxTurns[agentDef.ID] = cg.MaxTurns
 			}
+			if cg.MaxTokens > 0 {
+				maxTokens[agentDef.ID] = cg.MaxTokens
+			}
 		}
 		launcherCfg.PluginConfig = contextguard.NewPluginConfig(contextguard.Config{
 			Registry:   cwRegistry,
 			Models:     guardLLMs,
 			Strategies: strategies,
 			MaxTurns:   maxTurns,
+			MaxTokens:  maxTokens,
 		})
 	}
 

--- a/server/clients/discord/bot.go
+++ b/server/clients/discord/bot.go
@@ -215,6 +215,8 @@ func (c *Client) handleTextMessage(s *discordgo.Session, m *discordgo.MessageCre
 		switch evt.Type {
 		case msgutil.SSEEventText:
 			hasText = true
+			toolCount = 0
+			toolCounterMsgID = ""
 			chunks := msgutil.SplitMessage(evt.Text, msgutil.DiscordMaxMessageLength)
 			for i, chunk := range chunks {
 				msg := &discordgo.MessageSend{Content: chunk}
@@ -361,6 +363,8 @@ func (c *Client) handleVoice(s *discordgo.Session, m *discordgo.MessageCreate) {
 		case msgutil.SSEEventText:
 			hasText = true
 			lastTextResponse = evt.Text
+			toolCount = 0
+			toolCounterMsgID = ""
 			mode := c.getResponseMode()
 			sendText := mode != ResponseModeVoice && (mode != ResponseModeMirror || false)
 			if mode == ResponseModeBoth || mode == ResponseModeText || (mode == ResponseModeMirror && false) {

--- a/server/clients/msgutil/sse.go
+++ b/server/clients/msgutil/sse.go
@@ -1,0 +1,268 @@
+package msgutil
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// SSEEventType classifies the type of event received from the ADK /run_sse endpoint.
+type SSEEventType int
+
+const (
+	SSEEventText       SSEEventType = iota // Agent produced text content
+	SSEEventToolCall                       // Agent called a tool (functionCall)
+	SSEEventToolResult                     // Tool returned a result (functionResponse)
+	SSEEventUnknown                        // Unrecognized event
+)
+
+// SSEEvent represents a single parsed event from the ADK /run_sse stream.
+type SSEEvent struct {
+	Type       SSEEventType
+	Author     string
+	Text       string
+	ToolName   string
+	ToolArgs   interface{}
+	ToolResult interface{}
+	Raw        map[string]interface{}
+}
+
+// ParseSSEStream reads a /run_sse response body and calls handler for each
+// meaningful event as it arrives. The handler receives events one at a time.
+// This is a blocking call that returns when the stream ends or an error occurs.
+func ParseSSEStream(reader io.Reader, handler func(SSEEvent)) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "" {
+			continue
+		}
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal([]byte(data), &raw); err != nil {
+			continue
+		}
+
+		events := classifyEvent(raw)
+		for _, evt := range events {
+			handler(evt)
+		}
+	}
+
+	return scanner.Err()
+}
+
+// classifyEvent examines a raw ADK event JSON and returns one or more typed SSEEvents.
+func classifyEvent(raw map[string]interface{}) []SSEEvent {
+	author, _ := raw["author"].(string)
+
+	content, ok := raw["content"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	parts, ok := content["parts"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var events []SSEEvent
+
+	for _, part := range parts {
+		partMap, ok := part.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if text, ok := partMap["text"].(string); ok && text != "" {
+			events = append(events, SSEEvent{
+				Type:   SSEEventText,
+				Author: author,
+				Text:   text,
+				Raw:    raw,
+			})
+		}
+
+		if fc, ok := partMap["functionCall"].(map[string]interface{}); ok {
+			name, _ := fc["name"].(string)
+			events = append(events, SSEEvent{
+				Type:     SSEEventToolCall,
+				Author:   author,
+				ToolName: name,
+				ToolArgs: fc["args"],
+				Raw:      raw,
+			})
+		}
+
+		if fr, ok := partMap["functionResponse"].(map[string]interface{}); ok {
+			name, _ := fr["name"].(string)
+			events = append(events, SSEEvent{
+				Type:       SSEEventToolResult,
+				Author:     author,
+				ToolName:   name,
+				ToolResult: fr["response"],
+				Raw:        raw,
+			})
+		}
+	}
+
+	return events
+}
+
+// CollectSSEEvents is a convenience wrapper that reads the full SSE stream
+// and returns all events and the aggregated text response.
+func CollectSSEEvents(reader io.Reader) ([]SSEEvent, string, error) {
+	var events []SSEEvent
+	var textParts []string
+
+	err := ParseSSEStream(reader, func(evt SSEEvent) {
+		events = append(events, evt)
+		if evt.Type == SSEEventText {
+			textParts = append(textParts, evt.Text)
+		}
+	})
+
+	fullText := strings.Join(textParts, "")
+	if fullText == "" {
+		fullText = "(no response)"
+	}
+
+	return events, fullText, err
+}
+
+// FormatToolCallTelegram formats a single tool call as a Telegram expandable
+// blockquote. The tool name is always visible; args are human-readable inside.
+func FormatToolCallTelegram(evt SSEEvent) string {
+	lines := humanArgLines(evt.ToolArgs)
+	if len(lines) == 0 {
+		return fmt.Sprintf("<blockquote>🔧 <b>%s</b></blockquote>", escapeHTML(evt.ToolName))
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("<blockquote expandable>🔧 <b>%s</b>\n", escapeHTML(evt.ToolName)))
+	for _, l := range lines {
+		b.WriteString(fmt.Sprintf("<b>%s</b>: %s\n", escapeHTML(l.Key), escapeHTML(l.Value)))
+	}
+	b.WriteString("</blockquote>")
+	return b.String()
+}
+
+// FormatToolCallDiscord formats a single tool call for Discord.
+func FormatToolCallDiscord(evt SSEEvent) string {
+	lines := humanArgLines(evt.ToolArgs)
+	if len(lines) == 0 {
+		return fmt.Sprintf("> 🔧 **%s**", evt.ToolName)
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("> 🔧 **%s**\n", evt.ToolName))
+	for _, l := range lines {
+		b.WriteString(fmt.Sprintf("> **%s**: %s\n", l.Key, l.Value))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// FormatToolCallSlack formats a single tool call for Slack.
+func FormatToolCallSlack(evt SSEEvent) string {
+	lines := humanArgLines(evt.ToolArgs)
+	if len(lines) == 0 {
+		return fmt.Sprintf("> 🔧 *%s*", evt.ToolName)
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("> 🔧 *%s*\n", evt.ToolName))
+	for _, l := range lines {
+		b.WriteString(fmt.Sprintf("> *%s*: %s\n", l.Key, l.Value))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// argLine holds a key-value pair from tool arguments.
+type argLine struct {
+	Key   string
+	Value string
+}
+
+// humanArgLines converts tool arguments into human-readable key-value pairs.
+func humanArgLines(args interface{}) []argLine {
+	if args == nil {
+		return nil
+	}
+	m, ok := args.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var lines []argLine
+	for _, k := range keys {
+		v := m[k]
+		s := humanValue(v)
+		if s == "" {
+			continue
+		}
+		lines = append(lines, argLine{Key: k, Value: s})
+	}
+	return lines
+}
+
+// humanValue formats a single value for human reading.
+func humanValue(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	case nil:
+		return ""
+	case []interface{}:
+		if len(val) == 0 {
+			return "[]"
+		}
+		var items []string
+		for _, item := range val {
+			items = append(items, humanValue(item))
+			if len(items) >= 5 {
+				items = append(items, "…")
+				break
+			}
+		}
+		return "[" + strings.Join(items, ", ") + "]"
+	case map[string]interface{}:
+		b, _ := json.Marshal(val)
+		s := string(b)
+		if len(s) > 80 {
+			s = s[:80] + "…"
+		}
+		return s
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func escapeHTML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}

--- a/server/clients/slack/bot.go
+++ b/server/clients/slack/bot.go
@@ -584,6 +584,8 @@ func (c *Client) processMessage(userID, channelID, channelType, text, threadTS, 
 		case msgutil.SSEEventText:
 			hasText = true
 			lastTextResponse = evt.Text
+			toolCount = 0
+			toolCounterTS = ""
 			c.sendTextMessage(channelID, evt.Text, threadTS, inputWasVoice)
 		case msgutil.SSEEventToolCall:
 			if c.getShowTools() {

--- a/server/clients/telegram/bot.go
+++ b/server/clients/telegram/bot.go
@@ -430,8 +430,10 @@ func (c *Client) handleMessage(ctx *th.Context, msg telego.Message) error {
 
 	hasText := false
 	toolCount := 0
+	eventCount := 0
 	var toolCounterMsgID int
 	err := c.callAgentSSE(msg, inputText, func(evt msgutil.SSEEvent) {
+		eventCount++
 		switch evt.Type {
 		case msgutil.SSEEventText:
 			hasText = true
@@ -480,6 +482,13 @@ func (c *Client) handleMessage(ctx *th.Context, msg telego.Message) error {
 	}
 
 	if !hasText {
+		c.logger.Warn("No text in agent response",
+			"chat_id", msg.Chat.ID,
+			"agent", agentID,
+			"session", sessionID,
+			"events_received", eventCount,
+			"tool_calls", toolCount,
+		)
 		_, _ = ctx.Bot().SendMessage(ctx, &telego.SendMessageParams{
 			ChatID: tu.ID(msg.Chat.ID),
 			Text:   "I couldn't generate a response.",

--- a/server/clients/telegram/bot.go
+++ b/server/clients/telegram/bot.go
@@ -435,6 +435,8 @@ func (c *Client) handleMessage(ctx *th.Context, msg telego.Message) error {
 		switch evt.Type {
 		case msgutil.SSEEventText:
 			hasText = true
+			toolCount = 0
+			toolCounterMsgID = 0
 			c.sendTextResponse(ctx, msg.Chat.ID, evt.Text, false)
 		case msgutil.SSEEventToolCall:
 			if c.getShowTools() {
@@ -593,6 +595,8 @@ func (c *Client) handleVoice(ctx *th.Context, msg telego.Message) error {
 		case msgutil.SSEEventText:
 			hasText = true
 			lastTextResponse = evt.Text
+			toolCount = 0
+			toolCounterMsgID = 0
 			c.sendTextResponse(ctx, msg.Chat.ID, evt.Text, true)
 		case msgutil.SSEEventToolCall:
 			if c.getShowTools() {

--- a/server/main.go
+++ b/server/main.go
@@ -160,8 +160,9 @@ func main() {
 	executor.SetConversationStore(convoStore)
 
 	httpMux := http.NewServeMux()
-	// Chain: Client ← RecorderUser ← FlowFilter ← RecorderAdmin ← SessionEnsure ← SessionStateSeed ← ADK
-	seeded := middleware.SessionEnsure(middleware.SessionStateSeed(agentRouter, dataStore))
+	// Chain: Client ← RecorderUser ← FlowFilter ← RecorderAdmin ← SessionEnsure ← SessionStateSeed ← SSEIdleTimeout ← ADK
+	idleGuarded := middleware.SSEIdleTimeout(agentRouter, 15*time.Minute)
+	seeded := middleware.SessionEnsure(middleware.SessionStateSeed(idleGuarded, dataStore))
 	adminRecorded := middleware.ConversationRecorder(
 		middleware.ConversationRecorderSSE(seeded, executor, dataStore, "admin"),
 		executor, dataStore, "admin",

--- a/server/middleware/flowfilter.go
+++ b/server/middleware/flowfilter.go
@@ -84,6 +84,10 @@ func (f *filteringSSEWriter) Flush() {
 	}
 }
 
+func (f *filteringSSEWriter) Unwrap() http.ResponseWriter {
+	return f.ResponseWriter
+}
+
 // sessionGetRe matches GET /…/apps/{appName}/users/{userId}/sessions/{sessionId}
 var sessionGetRe = regexp.MustCompile(`/apps/([^/]+)/users/[^/]+/sessions/[^/]+$`)
 

--- a/server/middleware/recorder.go
+++ b/server/middleware/recorder.go
@@ -31,6 +31,10 @@ func (r *bodyCapture) Write(b []byte) (int, error) {
 	return r.ResponseWriter.Write(b)
 }
 
+func (r *bodyCapture) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
 // ConversationRecorder wraps an HTTP handler to intercept /run calls and log
 // conversations to the conversation store. The perspective parameter determines
 // whether this logs the "admin" (all events) or "user" (filtered) view.
@@ -200,6 +204,10 @@ func (r *sseResponseRecorder) Flush() {
 	if r.flusher != nil {
 		r.flusher.Flush()
 	}
+}
+
+func (r *sseResponseRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
 }
 
 func parseSSEEvents(raw string) []map[string]interface{} {

--- a/server/middleware/sseidle.go
+++ b/server/middleware/sseidle.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+type sseIdleWriter struct {
+	http.ResponseWriter
+	rc      *http.ResponseController
+	timeout time.Duration
+}
+
+func (w *sseIdleWriter) Write(b []byte) (int, error) {
+	w.rc.SetWriteDeadline(time.Now().Add(w.timeout))
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *sseIdleWriter) Flush() {
+	w.rc.Flush()
+}
+
+func (w *sseIdleWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func SSEIdleTimeout(next http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.HasSuffix(r.URL.Path, "/run_sse") && r.Method == "POST") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		iw := &sseIdleWriter{
+			ResponseWriter: w,
+			rc:             http.NewResponseController(w),
+			timeout:        timeout,
+		}
+		next.ServeHTTP(iw, r)
+	})
+}

--- a/server/plugin/contextguard/contextguard.go
+++ b/server/plugin/contextguard/contextguard.go
@@ -138,6 +138,7 @@ type Config struct {
 	Models     map[string]model.LLM
 	Strategies map[string]string // agent ID → StrategyThreshold | StrategySlidingWindow
 	MaxTurns   map[string]int    // agent ID → max Content entries (sliding window only)
+	MaxTokens  map[string]int    // agent ID → manual token threshold (0 = auto)
 }
 
 // NewPluginConfig creates a runner.PluginConfig ready to be passed to the
@@ -156,7 +157,7 @@ func NewPluginConfig(cfg Config) runner.PluginConfig {
 			}
 			strategies[agentID] = newSlidingWindowStrategy(cfg.Registry, llm, maxTurns)
 		default:
-			strategies[agentID] = newThresholdStrategy(cfg.Registry, llm)
+			strategies[agentID] = newThresholdStrategy(cfg.Registry, llm, cfg.MaxTokens[agentID])
 		}
 		slog.Info("ContextGuard: strategy configured",
 			"agent", agentID,

--- a/server/store/types.go
+++ b/server/store/types.go
@@ -58,9 +58,10 @@ type TTSRef struct {
 // the selected Strategy. When Enabled is false (or the struct is nil)
 // the plugin does nothing for this agent.
 type ContextGuardConfig struct {
-	Enabled  bool   `json:"enabled" yaml:"enabled"`
-	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
-	MaxTurns int    `json:"maxTurns,omitempty" yaml:"maxTurns,omitempty"`
+	Enabled   bool   `json:"enabled" yaml:"enabled"`
+	Strategy  string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	MaxTurns  int    `json:"maxTurns,omitempty" yaml:"maxTurns,omitempty"`
+	MaxTokens int    `json:"maxTokens,omitempty" yaml:"maxTokens,omitempty"`
 }
 
 // MemoryProvider represents a reusable memory backend (Redis, Postgres, etc.).


### PR DESCRIPTION
## Summary

  Switch all clients (Telegram, Slack, Discord, executor) from blocking `/run` to streaming `/run_sse` via Server-Sent
Events. Responses now arrive incrementally instead of waiting for full completion.

  - Shared `msgutil.ParseSSEStream` parser for all clients — classifies SSE events into text, tool calls, and tool
results
  - New middleware stack for SSE: `SSEIdleTimeout` (15min), `ConversationRecorderSSE` (admin + user perspectives),
`FlowResponseFilter` real-time stream filtering
  - All response writer wrappers implement `Unwrap()` for proper `http.ResponseController` compatibility
  - Configurable `maxTokens` for Context Guard threshold strategy — overrides auto-detected model limit, exposed in
admin UI
  - Tool call counter resets between text responses to prevent bleed across cycles
  - Diagnostic logging when agent returns empty response (`events_received`, `tool_calls` count)
  - Number input spinners hidden in admin UI for cleaner dark theme

## Test plan

  - [ ] Send messages via Telegram — verify text streams incrementally with typing indicator
  - [ ] Send messages via Slack — verify threaded responses and emoji reactions
  - [ ] Send messages via Discord — verify DM and channel @mention responses
  - [ ] Verify tool call counter resets after each text response
  - [ ] Trigger Context Guard with custom `maxTokens` value — confirm summarization fires at configured threshold
  - [ ] Leave `maxTokens` empty — confirm auto-detection from model works as before
  - [ ] Test flow execution — verify only response agent events reach the client
  - [ ] Verify conversation recordings show in admin UI for both admin and user perspectives
  - [ ] Confirm SSE idle timeout closes stale connections after 15min inactivity