### PR TITLE
Feat/use new tokenthreshold compactor

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -45,6 +45,7 @@ ARG TARGETARCH
 
 WORKDIR /build
 
+COPY adk-utils-go/ /adk-utils-go/
 COPY server/go.mod server/go.sum ./
 RUN go mod download
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -45,7 +45,6 @@ ARG TARGETARCH
 
 WORKDIR /build
 
-COPY adk-utils-go/ /adk-utils-go/
 COPY server/go.mod server/go.sum ./
 RUN go mod download
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -25,7 +25,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace github.com/achetronic/adk-utils-go => ../adk-utils-go
+
 require (
+	charm.land/catwalk v0.25.0 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.17.0 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
@@ -37,6 +40,7 @@ require (
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/x/etag v0.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/server/go.mod
+++ b/server/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/a2aproject/a2a-go v0.3.3
-	github.com/achetronic/adk-utils-go v0.8.2
+	github.com/achetronic/adk-utils-go v0.9.0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/google/jsonschema-go v0.3.0
@@ -24,8 +24,6 @@ require (
 	google.golang.org/genai v1.40.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/achetronic/adk-utils-go => ../adk-utils-go
 
 require (
 	charm.land/catwalk v0.25.0 // indirect

--- a/server/go.mod
+++ b/server/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/a2aproject/a2a-go v0.3.3
-	github.com/achetronic/adk-utils-go v0.9.0
+	github.com/achetronic/adk-utils-go v0.9.1
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/google/jsonschema-go v0.3.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -11,8 +11,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/a2aproject/a2a-go v0.3.3 h1:NqGDw2c8hCSW3/9MakeeRpw5yCZUUmW2Y/yINV15GwQ=
 github.com/a2aproject/a2a-go v0.3.3/go.mod h1:8C0O6lsfR7zWFEqVZz/+zWCoxe8gSWpknEpqm/Vgj3E=
-github.com/achetronic/adk-utils-go v0.9.0 h1:WBH075eqJk6qMzSHAYnV+CyKc9P5l28SeXTaDyK2N9w=
-github.com/achetronic/adk-utils-go v0.9.0/go.mod h1:9/8fMfP8VMIy3wU4Lgctw6ksrKxpuRKYo6vUEcQqTeg=
+github.com/achetronic/adk-utils-go v0.9.1 h1:e8MXfscsQAz4dRwufMPyyuoGiEqox14UbeUPzmfEAD0=
+github.com/achetronic/adk-utils-go v0.9.1/go.mod h1:9/8fMfP8VMIy3wU4Lgctw6ksrKxpuRKYo6vUEcQqTeg=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anthropics/anthropic-sdk-go v1.19.0 h1:mO6E+ffSzLRvR/YUH9KJC0uGw0uV8GjISIuzem//3KE=

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+charm.land/catwalk v0.25.0 h1:bRkP8NPm3Tc+R89yVmaAQVk1jtyWxENJRu6BXwkCo8I=
+charm.land/catwalk v0.25.0/go.mod h1:rFC/V96rIHX7VES215c/qzI1EW/Moo1ggs1Q6seTy5s=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
 cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7bImXLTAZU=
 cloud.google.com/go/auth v0.17.0 h1:74yCm7hCj2rUyyAocqnFzsAYXgJhrG26XCFimrc/Kz4=
@@ -9,8 +11,6 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/a2aproject/a2a-go v0.3.3 h1:NqGDw2c8hCSW3/9MakeeRpw5yCZUUmW2Y/yINV15GwQ=
 github.com/a2aproject/a2a-go v0.3.3/go.mod h1:8C0O6lsfR7zWFEqVZz/+zWCoxe8gSWpknEpqm/Vgj3E=
-github.com/achetronic/adk-utils-go v0.8.2 h1:JBUuVxbXUlPGIVx1HNlvHMyCePLpdTz1as2hUkzkG8Q=
-github.com/achetronic/adk-utils-go v0.8.2/go.mod h1:HyXTRn92N+IBGcYI5Rt00BozUW5YLvz2p0bw4dJqBwM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anthropics/anthropic-sdk-go v1.19.0 h1:mO6E+ffSzLRvR/YUH9KJC0uGw0uV8GjISIuzem//3KE=
@@ -31,6 +31,8 @@ github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiD
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charmbracelet/x/etag v0.2.0 h1:Euj1VkheoHfTYA9y+TCwkeXF/hN8Fb9l4LqZl79pt04=
+github.com/charmbracelet/x/etag v0.2.0/go.mod h1:C1B7/bsgvzzxpfu0Rabbd+rTHJa5TmC/qgTseCf6DF0=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=

--- a/server/go.sum
+++ b/server/go.sum
@@ -11,6 +11,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/a2aproject/a2a-go v0.3.3 h1:NqGDw2c8hCSW3/9MakeeRpw5yCZUUmW2Y/yINV15GwQ=
 github.com/a2aproject/a2a-go v0.3.3/go.mod h1:8C0O6lsfR7zWFEqVZz/+zWCoxe8gSWpknEpqm/Vgj3E=
+github.com/achetronic/adk-utils-go v0.9.0 h1:WBH075eqJk6qMzSHAYnV+CyKc9P5l28SeXTaDyK2N9w=
+github.com/achetronic/adk-utils-go v0.9.0/go.mod h1:9/8fMfP8VMIy3wU4Lgctw6ksrKxpuRKYo6vUEcQqTeg=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anthropics/anthropic-sdk-go v1.19.0 h1:mO6E+ffSzLRvR/YUH9KJC0uGw0uV8GjISIuzem//3KE=

--- a/server/main.go
+++ b/server/main.go
@@ -138,10 +138,8 @@ func main() {
 		}
 	}()
 
-	// cwRegistry caches LLM context window sizes fetched from Crush.
-	// It starts a background goroutine that refreshes every 6 hours.
+	// cwRegistry provides LLM context window sizes from catwalk's embedded database.
 	cwRegistry := contextguard.NewCrushRegistry()
-	cwRegistry.Start(ctx)
 
 	// A2A (Agent-to-Agent) protocol handler
 	a2aPublicURL := cfg.Server.PublicURL
@@ -300,7 +298,6 @@ func main() {
 		slog.Info("Shutting down...")
 		cronScheduler.Stop()
 		cm.stop()
-		cwRegistry.Stop()
 		if voiceDetector != nil {
 			voiceDetector.Close()
 		}


### PR DESCRIPTION
Switch to the new  TokenThreshold  compactor from  adk-utils-go  v0.9.1.

The context window registry now resolves LLM sizes from an embedded database (catwalk) instead of fetching them from a remote API in the background. This removes the  Start / Stop  lifecycle and the periodic refresh goroutine — simpler
setup, fewer moving parts.