### PR TITLE
fix: Improve visual workflows UX

### DIFF
--- a/frontend/admin-ui/src/views/flows/FlowCanvas.vue
+++ b/frontend/admin-ui/src/views/flows/FlowCanvas.vue
@@ -283,16 +283,27 @@ const flowItems = [
 ]
 
 function onToolbarDragStart(e, item) {
+  const dragType = item.type === 'agent' ? 'agent' : item.subtype
   e.dataTransfer.effectAllowed = 'copy'
-  e.dataTransfer.setData('text/plain', JSON.stringify({
-    type: item.type === 'agent' ? 'agent' : item.subtype,
-    fromToolbar: true,
-  }))
-  document.body.classList.add('flow-dragging-from-toolbar')
+  e.dataTransfer.setData('text/plain', JSON.stringify({ type: dragType, fromToolbar: true }))
+  document.body.dataset.toolbarDragType = dragType
+}
+
+function stripPlaceholders(step) {
+  if (!step?.steps) return step
+  return {
+    ...step,
+    steps: step.steps
+      .filter(s => !s.__placeholder)
+      .map(s => s.steps ? stripPlaceholders(s) : s),
+  }
 }
 
 function onToolbarDragEnd() {
-  document.body.classList.remove('flow-dragging-from-toolbar')
+  delete document.body.dataset.toolbarDragType
+  if (props.modelValue) {
+    emit('update:modelValue', stripPlaceholders(props.modelValue))
+  }
 }
 
 onMounted(() => {


### PR DESCRIPTION
Unify drag-and-drop placeholder behavior in the flow editor.

When dragging a new item from the sidebar into a container, the editor now shows a ghost of the actual block (agent or container) at the drop position — the same look as when reordering existing items. Siblings reflow to make room instead of showing a floating indicator bar. Uses  relatedTarget -based leave detection and a dead zone around the placeholder to prevent jittery repositioning.