### PR TITLE
feat(#24): add anthropic oauth client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ test/
 data/*
 !data/seeds/
 server/data/
+onnxruntime-*/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-admin build-voice dev dev-admin dev-voice clean download-model swagger docker-build docker-buildx docker-push postgres redis ollama infra infra-stop infra-clean
+.PHONY: help build build-admin build-voice dev dev-admin dev-voice clean download-model swagger docker-build docker-buildx docker-push postgres redis ollama infra infra-stop infra-clean docs docs-stop
 
 CONFIG ?= config.yaml
 
@@ -15,6 +15,8 @@ help:
 	@echo "  dev-admin            Start admin UI dev server (Vite, port 5173)"
 	@echo "  dev-voice            Start voice UI dev server (Vite, port 5174)"
 	@echo "  swagger              Regenerate Swagger docs from annotations"
+	@echo "  docs                 Start documentation site (Hugo, port 1313)"
+	@echo "  docs-stop            Stop documentation site"
 	@echo "  clean                Remove generated files"
 	@echo ""
 	@echo "Models:"
@@ -101,6 +103,26 @@ docker-buildx:
 docker-push:
 	@docker buildx build -f docker/build/Dockerfile --platform $(DOCKER_PLATFORMS) -t $(IMAGE_NAME):$(IMAGE_TAG) --push .
 	@echo "Image pushed: $(IMAGE_NAME):$(IMAGE_TAG) [$(DOCKER_PLATFORMS)]"
+
+# Documentation (Docker)
+
+HUGO_VERSION ?= 0.147.1
+DOCS_PORT ?= 1313
+
+docs:
+	@echo "Starting documentation site on http://localhost:$(DOCS_PORT) ..."
+	@docker run -d --name magec-docs \
+		-p $(DOCS_PORT):1313 \
+		-v $(CURDIR)/website:/src \
+		hugomods/hugo:$(HUGO_VERSION) \
+		hugo server --bind 0.0.0.0 --baseURL http://localhost:$(DOCS_PORT) --disableFastRender
+	@echo "Documentation site running at http://localhost:$(DOCS_PORT)"
+	@echo "Stop with: make docs-stop"
+
+docs-stop:
+	@docker stop magec-docs 2>/dev/null || true
+	@docker rm magec-docs 2>/dev/null || true
+	@echo "Documentation site stopped"
 
 # Infrastructure (Docker)
 

--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -92,8 +92,18 @@ services:
       - REQUIRE_API_KEY=False
     restart: unless-stopped
 
+  cliproxyapi:
+    image: eceasy/cli-proxy-api:latest
+    ports:
+      - "54545:54545"   # OAuth callback (required for login only)
+    volumes:
+      - ./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml
+      - cliproxyapi_auth:/CLIProxyAPI/auth
+    restart: unless-stopped
+
 volumes:
   magec_data:
   redis_data:
   postgres_data:
   ollama_data:
+  cliproxyapi_auth:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -333,7 +333,7 @@ choose \
 
 LLM_CHOICE="$REPLY"
 
-# ── CLIProxyAPI (use Claude subscription as API) ─────────────────────────
+# ── CLIProxyAPI (use provider subscription as API) ───────────────────────
 
 WANT_CLIPROXYAPI=false
 
@@ -341,26 +341,27 @@ if [[ "$LLM_CHOICE" == "2" || "$LLM_CHOICE" == "3" ]]; then
   echo
   box_top
   box_empty
-  box_line "  Use Claude Without an API Key?" "$BOLD" "center"
+  box_line "  Use Your Subscription Instead of an API Key?" "$BOLD" "center"
   box_empty
   box_sep
   box_empty
-  box_line "  If you have a Claude Max or Pro subscription,"
-  box_line "  you can use your existing account instead of"
-  box_line "  paying separately for API access."
+  box_line "  Some AI providers offer paid subscriptions"
+  box_line "  (e.g., Claude Max/Pro, ChatGPT Plus) that are"
+  box_line "  separate from their API billing."
   box_empty
-  box_line "  This uses CLIProxyAPI — a local proxy that"
-  box_line "  connects your Claude subscription to Magec."
-  box_line "  You'll log in with your Anthropic account once,"
-  box_line "  and Magec can use Claude models from there."
+  box_line "  CLIProxyAPI is a local proxy that lets you"
+  box_line "  use your existing subscription with Magec"
+  box_line "  instead of paying separately for API access."
+  box_line "  You log in once and Magec can use the models"
+  box_line "  from your subscription."
   box_empty
-  box_line "  ${DIM}You can still add a regular Anthropic API key${NC}"
-  box_line "  ${DIM}later if you prefer.${NC}"
+  box_line "  ${DIM}You can still add a regular API key later${NC}"
+  box_line "  ${DIM}if you prefer.${NC}"
   box_empty
   box_bottom
   echo
 
-  if ask_yn "Enable Claude subscription proxy (CLIProxyAPI)?" "n"; then
+  if ask_yn "Enable subscription proxy (CLIProxyAPI)?" "n"; then
     WANT_CLIPROXYAPI=true
     ok "CLIProxyAPI will be configured"
   else
@@ -763,7 +764,7 @@ box_line "  ${BOLD}Install method:${NC}    $method_label"
 box_line "  ${BOLD}System:${NC}            ${os_label} (${arch_label})"
 box_line "  ${BOLD}AI models:${NC}         $llm_label"
 if $WANT_CLIPROXYAPI; then
-  box_line "  ${BOLD}Claude proxy:${NC}      Enabled (CLIProxyAPI)"
+  box_line "  ${BOLD}Subscription proxy:${NC} Enabled (CLIProxyAPI)"
 fi
 box_line "  ${BOLD}Conversation memory:${NC} $($WANT_REDIS && echo "Yes" || echo "No")"
 box_line "  ${BOLD}Long-term memory:${NC}  $($WANT_POSTGRES && echo "Yes" || echo "No")"
@@ -1357,7 +1358,7 @@ install_binary() {
   if $WANT_CLIPROXYAPI; then
     cls
     echo
-    printf "  $(badge " SETUP " "$BG_YELLOW" "$FG_BLACK")  ${BOLD}Claude subscription proxy (CLIProxyAPI)${NC}\n"
+    printf "  $(badge " SETUP " "$BG_YELLOW" "$FG_BLACK")  ${BOLD}Subscription proxy (CLIProxyAPI)${NC}\n"
     printf "  ${DIM}$(hline '─' "$BOX_W")${NC}\n"
     echo
 
@@ -1386,17 +1387,10 @@ install_binary() {
     box_empty
     box_sep
     box_empty
-    box_line "  ${BOLD}After starting, log in with your Claude account:${NC}"
+    box_line "  ${BOLD}After starting, log in to your provider.${NC}"
+    box_line "  ${BOLD}See the guide for supported providers:${NC}"
     box_empty
-    box_line "  ${CYAN}cliproxyapi --claude-login${NC}"
-    box_line "  ${DIM}(or via Docker:${NC}"
-    box_line "  ${DIM}  docker stop magec-cliproxyapi${NC}"
-    box_line "  ${DIM}  docker run --rm -p 54545:54545 \\${NC}"
-    box_line "  ${DIM}    -v ./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml \\${NC}"
-    box_line "  ${DIM}    -v magec_cliproxyapi_auth:/CLIProxyAPI/auth \\${NC}"
-    box_line "  ${DIM}    eceasy/cli-proxy-api:latest \\${NC}"
-    box_line "  ${DIM}    /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login${NC}"
-    box_line "  ${DIM}  docker start magec-cliproxyapi)${NC}"
+    box_line "  ${CYAN}https://magec.dev/docs/subscription-proxy/${NC}"
     box_empty
     box_bottom
     echo
@@ -1660,7 +1654,7 @@ generate_store_json() {
   if $WANT_CLIPROXYAPI; then
     local cliproxyapi_url="http://localhost:8317"
     [[ "$INSTALL_METHOD" == "2" ]] && cliproxyapi_url="http://cliproxyapi:8317"
-    backend_entries+=("{\"id\":\"${cliproxyapi_backend_id}\",\"name\":\"Claude (Subscription)\",\"type\":\"anthropic\",\"url\":\"${cliproxyapi_url}\",\"apiKey\":\"sk-magec-local\"}")
+    backend_entries+=("{\"id\":\"${cliproxyapi_backend_id}\",\"name\":\"Subscription Proxy\",\"type\":\"anthropic\",\"url\":\"${cliproxyapi_url}\",\"apiKey\":\"sk-magec-local\"}")
   fi
 
   if [[ "$WANT_VOICE" == true ]]; then
@@ -2041,17 +2035,13 @@ EOF
   if $WANT_CLIPROXYAPI; then
     box_sep
     box_empty
-    box_line "  ${YELLOW}Action needed:${NC} Log in to your Claude account."
-    if [[ "$INSTALL_METHOD" == "2" ]]; then
-      box_line "  ${CYAN}${COMPOSE} stop cliproxyapi${NC}"
-      box_line "  ${CYAN}${COMPOSE} run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login${NC}"
-      box_line "  ${CYAN}${COMPOSE} up -d cliproxyapi${NC}"
-    else
-      box_line "  ${CYAN}cliproxyapi --claude-login${NC}"
-      box_line "  ${DIM}(or via Docker: stop, run login, restart)${NC}"
-    fi
+    box_line "  ${YELLOW}Action needed:${NC} Log in to your provider."
+    box_line "  See the subscription proxy guide for login"
+    box_line "  commands for each supported provider:"
     box_empty
-    box_line "  A \"${BOLD}Claude (Subscription)${NC}\" backend has been"
+    box_line "  ${CYAN}https://magec.dev/docs/subscription-proxy/${NC}"
+    box_empty
+    box_line "  A subscription proxy backend has been"
     box_line "  pre-configured. After login, it's ready to use."
     box_empty
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -333,6 +333,41 @@ choose \
 
 LLM_CHOICE="$REPLY"
 
+# ── CLIProxyAPI (use Claude subscription as API) ─────────────────────────
+
+WANT_CLIPROXYAPI=false
+
+if [[ "$LLM_CHOICE" == "2" || "$LLM_CHOICE" == "3" ]]; then
+  echo
+  box_top
+  box_empty
+  box_line "  Use Claude Without an API Key?" "$BOLD" "center"
+  box_empty
+  box_sep
+  box_empty
+  box_line "  If you have a Claude Max or Pro subscription,"
+  box_line "  you can use your existing account instead of"
+  box_line "  paying separately for API access."
+  box_empty
+  box_line "  This uses CLIProxyAPI — a local proxy that"
+  box_line "  connects your Claude subscription to Magec."
+  box_line "  You'll log in with your Anthropic account once,"
+  box_line "  and Magec can use Claude models from there."
+  box_empty
+  box_line "  ${DIM}You can still add a regular Anthropic API key${NC}"
+  box_line "  ${DIM}later if you prefer.${NC}"
+  box_empty
+  box_bottom
+  echo
+
+  if ask_yn "Enable Claude subscription proxy (CLIProxyAPI)?" "n"; then
+    WANT_CLIPROXYAPI=true
+    ok "CLIProxyAPI will be configured"
+  else
+    info "Skipped — you can set it up later"
+  fi
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════
 #  STEP 3 — MEMORY
 # ═══════════════════════════════════════════════════════════════════════════
@@ -727,6 +762,9 @@ box_empty
 box_line "  ${BOLD}Install method:${NC}    $method_label"
 box_line "  ${BOLD}System:${NC}            ${os_label} (${arch_label})"
 box_line "  ${BOLD}AI models:${NC}         $llm_label"
+if $WANT_CLIPROXYAPI; then
+  box_line "  ${BOLD}Claude proxy:${NC}      Enabled (CLIProxyAPI)"
+fi
 box_line "  ${BOLD}Conversation memory:${NC} $($WANT_REDIS && echo "Yes" || echo "No")"
 box_line "  ${BOLD}Long-term memory:${NC}  $($WANT_POSTGRES && echo "Yes" || echo "No")"
 box_line "  ${BOLD}Voice:${NC}             $voice_label"
@@ -1314,6 +1352,55 @@ install_binary() {
     install_onnx_runtime
   fi
 
+  # ── CLIProxyAPI setup (binary) ───────────────────────────────────────
+
+  if $WANT_CLIPROXYAPI; then
+    cls
+    echo
+    printf "  $(badge " SETUP " "$BG_YELLOW" "$FG_BLACK")  ${BOLD}Claude subscription proxy (CLIProxyAPI)${NC}\n"
+    printf "  ${DIM}$(hline '─' "$BOX_W")${NC}\n"
+    echo
+
+    box_top
+    box_empty
+    box_line "  CLIProxyAPI runs as a separate service."
+    box_line "  You can run it via Docker or download the"
+    box_line "  binary from GitHub."
+    box_empty
+    box_sep
+    box_empty
+    box_line "  ${BOLD}Option A — Docker (recommended):${NC}"
+    box_empty
+    box_line "  ${CYAN}docker run -d -p 8317:8317 -p 54545:54545 \\${NC}"
+    box_line "  ${CYAN}  -v \$(pwd)/cliproxyapi/config.yaml:\\${NC}"
+    box_line "  ${CYAN}  /CLIProxyAPI/config/config.yaml \\${NC}"
+    box_line "  ${CYAN}  -v cliproxyapi_auth:/CLIProxyAPI/auth \\${NC}"
+    box_line "  ${CYAN}  --name magec-cliproxyapi \\${NC}"
+    box_line "  ${CYAN}  eceasy/cli-proxy-api:latest${NC}"
+    box_empty
+    box_sep
+    box_empty
+    box_line "  ${BOLD}Option B — Binary:${NC}"
+    box_empty
+    box_line "  ${CYAN}https://github.com/router-for-me/CLIProxyAPI/releases${NC}"
+    box_empty
+    box_sep
+    box_empty
+    box_line "  ${BOLD}After starting, log in with your Claude account:${NC}"
+    box_empty
+    box_line "  ${CYAN}cliproxyapi --claude-login${NC}"
+    box_line "  ${DIM}(or: docker exec magec-cliproxyapi \\${NC}"
+    box_line "  ${DIM}  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login)${NC}"
+    box_empty
+    box_bottom
+    echo
+
+    printf "  ${DIM}Press Enter to continue...${NC}"
+    read -r < /dev/tty
+
+    generate_cliproxyapi_config
+  fi
+
   # ── Generate config ─────────────────────────────────────────────────
 
   echo
@@ -1458,6 +1545,9 @@ install_containers() {
 
   info "Creating configuration files..."
   generate_docker_compose
+  if $WANT_CLIPROXYAPI; then
+    generate_cliproxyapi_config
+  fi
   if ! $SKIP_CONFIG; then
     generate_config_yaml
   else
@@ -1484,6 +1574,18 @@ install_containers() {
 # ═══════════════════════════════════════════════════════════════════════════
 #  CONFIGURATION GENERATORS
 # ═══════════════════════════════════════════════════════════════════════════
+
+generate_cliproxyapi_config() {
+  mkdir -p cliproxyapi
+  cat > cliproxyapi/config.yaml <<'CLIPROXY'
+host: "0.0.0.0"
+port: 8317
+auth-dir: "/CLIProxyAPI/auth"
+api-keys:
+  - "sk-magec-local"
+CLIPROXY
+  ok "cliproxyapi/config.yaml"
+}
 
 generate_config_yaml() {
   local voice_enabled="true"
@@ -1533,6 +1635,7 @@ generate_store_json() {
   local openai_backend_id="$(gen_uuid)"
   local anthropic_backend_id="$(gen_uuid)"
   local gemini_backend_id="$(gen_uuid)"
+  local cliproxyapi_backend_id="$(gen_uuid)"
   local parakeet_backend_id="$(gen_uuid)"
   local tts_backend_id="$(gen_uuid)"
 
@@ -1546,6 +1649,12 @@ generate_store_json() {
     backend_entries+=("{\"id\":\"${openai_backend_id}\",\"name\":\"OpenAI\",\"type\":\"openai\",\"url\":\"https://api.openai.com/v1\",\"apiKey\":\"\"}")
     backend_entries+=("{\"id\":\"${anthropic_backend_id}\",\"name\":\"Anthropic\",\"type\":\"anthropic\",\"url\":\"\",\"apiKey\":\"\"}")
     backend_entries+=("{\"id\":\"${gemini_backend_id}\",\"name\":\"Gemini\",\"type\":\"gemini\",\"url\":\"\",\"apiKey\":\"\"}")
+  fi
+
+  if $WANT_CLIPROXYAPI; then
+    local cliproxyapi_url="http://localhost:8317"
+    [[ "$INSTALL_METHOD" == "2" ]] && cliproxyapi_url="http://cliproxyapi:8317"
+    backend_entries+=("{\"id\":\"${cliproxyapi_backend_id}\",\"name\":\"Claude (Subscription)\",\"type\":\"anthropic\",\"url\":\"${cliproxyapi_url}\",\"apiKey\":\"sk-magec-local\"}")
   fi
 
   if [[ "$WANT_VOICE" == true ]]; then
@@ -1601,6 +1710,9 @@ generate_store_json() {
   if [[ "$LLM_CHOICE" == "1" || "$LLM_CHOICE" == "3" ]]; then
     llm_backend_id="$ollama_backend_id"
     llm_model="qwen3:8b"
+  elif [[ "$LLM_CHOICE" == "2" ]] && $WANT_CLIPROXYAPI; then
+    llm_backend_id="$cliproxyapi_backend_id"
+    llm_model="claude-sonnet-4-20250514"
   elif [[ "$LLM_CHOICE" == "2" ]]; then
     llm_backend_id="$anthropic_backend_id"
     llm_model="claude-sonnet-4-20250514"
@@ -1771,6 +1883,18 @@ generate_docker_compose() {
     services+="    restart: unless-stopped\n"
   fi
 
+  if $WANT_CLIPROXYAPI; then
+    services+="\n  cliproxyapi:\n"
+    services+="    image: eceasy/cli-proxy-api:latest\n"
+    services+="    ports:\n"
+    services+="      - \"54545:54545\"\n"
+    services+="    volumes:\n"
+    services+="      - ./cliproxyapi/config.yaml:/CLIProxyAPI/config/config.yaml\n"
+    services+="      - cliproxyapi_auth:/CLIProxyAPI/auth\n"
+    services+="    restart: unless-stopped\n"
+    volumes+="  cliproxyapi_auth:\n"
+  fi
+
   printf "services:\n" > docker-compose.yaml
   printf '%b' "$services" >> docker-compose.yaml
   printf "\nvolumes:\n" >> docker-compose.yaml
@@ -1908,11 +2032,35 @@ EOF
   fi
   box_empty
 
-  if [[ "$LLM_CHOICE" == "2" || "$LLM_CHOICE" == "3" ]]; then
+  if $WANT_CLIPROXYAPI; then
+    box_sep
+    box_empty
+    box_line "  ${YELLOW}Action needed:${NC} Log in to your Claude account."
+    if [[ "$INSTALL_METHOD" == "2" ]]; then
+      box_line "  ${CYAN}${COMPOSE} exec cliproxyapi \\${NC}"
+      box_line "  ${CYAN}  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login${NC}"
+    else
+      box_line "  ${CYAN}cliproxyapi --claude-login${NC}"
+      box_line "  ${DIM}(or via Docker: docker exec magec-cliproxyapi \\${NC}"
+      box_line "  ${DIM}  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login)${NC}"
+    fi
+    box_empty
+    box_line "  A \"${BOLD}Claude (Subscription)${NC}\" backend has been"
+    box_line "  pre-configured. After login, it's ready to use."
+    box_empty
+  fi
+
+  if [[ "$LLM_CHOICE" == "2" || "$LLM_CHOICE" == "3" ]] && ! $WANT_CLIPROXYAPI; then
     box_sep
     box_empty
     box_line "  ${YELLOW}Remember:${NC} Cloud AI providers need API keys."
     box_line "  Add them in Admin Panel → Backends."
+    box_empty
+  elif [[ "$LLM_CHOICE" == "2" || "$LLM_CHOICE" == "3" ]] && $WANT_CLIPROXYAPI; then
+    box_sep
+    box_empty
+    box_line "  ${DIM}Other cloud providers (OpenAI, Gemini) still${NC}"
+    box_line "  ${DIM}need API keys — add them in Admin Panel → Backends.${NC}"
     box_empty
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1373,7 +1373,7 @@ install_binary() {
     box_empty
     box_line "  ${CYAN}docker run -d -p 8317:8317 -p 54545:54545 \\${NC}"
     box_line "  ${CYAN}  -v \$(pwd)/cliproxyapi/config.yaml:\\${NC}"
-    box_line "  ${CYAN}  /CLIProxyAPI/config/config.yaml \\${NC}"
+    box_line "  ${CYAN}  /CLIProxyAPI/config.yaml \\${NC}"
     box_line "  ${CYAN}  -v cliproxyapi_auth:/CLIProxyAPI/auth \\${NC}"
     box_line "  ${CYAN}  --name magec-cliproxyapi \\${NC}"
     box_line "  ${CYAN}  eceasy/cli-proxy-api:latest${NC}"
@@ -1389,8 +1389,14 @@ install_binary() {
     box_line "  ${BOLD}After starting, log in with your Claude account:${NC}"
     box_empty
     box_line "  ${CYAN}cliproxyapi --claude-login${NC}"
-    box_line "  ${DIM}(or: docker exec magec-cliproxyapi \\${NC}"
-    box_line "  ${DIM}  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login)${NC}"
+    box_line "  ${DIM}(or via Docker:${NC}"
+    box_line "  ${DIM}  docker stop magec-cliproxyapi${NC}"
+    box_line "  ${DIM}  docker run --rm -p 54545:54545 \\${NC}"
+    box_line "  ${DIM}    -v ./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml \\${NC}"
+    box_line "  ${DIM}    -v magec_cliproxyapi_auth:/CLIProxyAPI/auth \\${NC}"
+    box_line "  ${DIM}    eceasy/cli-proxy-api:latest \\${NC}"
+    box_line "  ${DIM}    /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login${NC}"
+    box_line "  ${DIM}  docker start magec-cliproxyapi)${NC}"
     box_empty
     box_bottom
     echo
@@ -1889,7 +1895,7 @@ generate_docker_compose() {
     services+="    ports:\n"
     services+="      - \"54545:54545\"\n"
     services+="    volumes:\n"
-    services+="      - ./cliproxyapi/config.yaml:/CLIProxyAPI/config/config.yaml\n"
+    services+="      - ./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml\n"
     services+="      - cliproxyapi_auth:/CLIProxyAPI/auth\n"
     services+="    restart: unless-stopped\n"
     volumes+="  cliproxyapi_auth:\n"
@@ -2037,12 +2043,12 @@ EOF
     box_empty
     box_line "  ${YELLOW}Action needed:${NC} Log in to your Claude account."
     if [[ "$INSTALL_METHOD" == "2" ]]; then
-      box_line "  ${CYAN}${COMPOSE} exec cliproxyapi \\${NC}"
-      box_line "  ${CYAN}  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login${NC}"
+      box_line "  ${CYAN}${COMPOSE} stop cliproxyapi${NC}"
+      box_line "  ${CYAN}${COMPOSE} run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login${NC}"
+      box_line "  ${CYAN}${COMPOSE} up -d cliproxyapi${NC}"
     else
       box_line "  ${CYAN}cliproxyapi --claude-login${NC}"
-      box_line "  ${DIM}(or via Docker: docker exec magec-cliproxyapi \\${NC}"
-      box_line "  ${DIM}  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login)${NC}"
+      box_line "  ${DIM}(or via Docker: stop, run login, restart)${NC}"
     fi
     box_empty
     box_line "  A \"${BOLD}Claude (Subscription)${NC}\" backend has been"

--- a/server/agent/agent.go
+++ b/server/agent/agent.go
@@ -413,6 +413,7 @@ func createLLM(ctx context.Context, backend store.BackendDefinition, llmRef stor
 	case config.BackendTypeAnthropic:
 		return genaianthro.New(genaianthro.Config{
 			APIKey:    backend.APIKey,
+			BaseURL:   backend.URL,
 			ModelName: llmRef.Model,
 			HTTPOptions: genaianthro.HTTPOptions{
 				Headers: headers,

--- a/website/content/docs/backends.md
+++ b/website/content/docs/backends.md
@@ -63,9 +63,64 @@ For Anthropic's Claude models. Uses the official Anthropic API protocol, which i
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Display name |
-| `apiKey` | Yes | Anthropic API key (starts with `sk-ant-`) |
+| `url` | No | API base URL. Defaults to `https://api.anthropic.com`. Set this when using a proxy like CLIProxyAPI. |
+| `apiKey` | Yes | Anthropic API key (starts with `sk-ant-`) or proxy API key |
 
 Anthropic doesn't offer STT, TTS, or embedding APIs, so this backend type is used only for LLM inference. For voice and embeddings, add a separate `openai`-type backend pointing at a local service.
+
+### Using your Claude subscription (CLIProxyAPI)
+
+If you have a Claude Max or Pro subscription, you can use your existing account instead of paying separately for API access. This works through [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), a local proxy that translates your subscription's OAuth credentials into a standard Anthropic API.
+
+#### 1. Create the backend
+
+In the Admin UI, create an `anthropic` backend pointing at CLIProxyAPI:
+
+| Field | Value |
+|-------|-------|
+| Name | `Claude (Subscription)` |
+| Type | `anthropic` |
+| URL | `http://cliproxyapi:8317` (Docker) or `http://localhost:8317` (local) |
+| API Key | `sk-magec-local` |
+
+{{< callout type="warning" >}}
+The **URL** field is required. Without it, Magec sends requests to the default Anthropic API (`https://api.anthropic.com`) and authentication will fail.
+{{< /callout >}}
+
+#### 2. Log in with your Claude account
+
+The login command starts a temporary OAuth callback server, so you must **stop the running CLIProxyAPI service first** to free its ports:
+
+```bash
+# Docker — stop, login, restart
+docker compose stop cliproxyapi
+docker compose run --rm --service-ports cliproxyapi \
+  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+docker compose up -d cliproxyapi
+
+# Binary
+cliproxyapi --claude-login
+```
+
+The command prints a URL like `https://claude.ai/oauth/authorize?...` — open it in your browser and authorize. After the OAuth callback completes, you'll see a success message. Your credentials are stored in the `cliproxyapi_auth` volume and persist across restarts.
+
+#### 3. Verify
+
+```bash
+curl http://localhost:8317/v1/models \
+  -H "X-Api-Key: sk-magec-local" \
+  -H "anthropic-version: 2023-06-01"
+```
+
+If you see a list of Claude models, CLIProxyAPI is working. You can now assign the backend to any agent.
+
+{{< callout type="info" >}}
+The interactive installer can set up CLIProxyAPI automatically. See [CLIProxyAPI on GitHub](https://github.com/router-for-me/CLIProxyAPI) for full configuration options.
+{{< /callout >}}
+
+{{< callout type="info" >}}
+CLIProxyAPI is a third-party project not affiliated with Anthropic. It uses your existing Claude subscription — you're responsible for ensuring your usage complies with Anthropic's terms of service.
+{{< /callout >}}
 
 ### Google Gemini (`gemini`)
 

--- a/website/content/docs/backends.md
+++ b/website/content/docs/backends.md
@@ -94,8 +94,7 @@ The login command starts a temporary OAuth callback server, so you must **stop t
 ```bash
 # Docker — stop, login, restart
 docker compose stop cliproxyapi
-docker compose run --rm --service-ports cliproxyapi \
-  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
 docker compose up -d cliproxyapi
 
 # Binary

--- a/website/content/docs/backends.md
+++ b/website/content/docs/backends.md
@@ -10,6 +10,10 @@ Every agent references a backend for its LLM. Optionally, an agent can also refe
 {{< screenshot src="img/screenshots/admin-backends.png" alt="Admin UI — Backends" >}}
 </div>
 
+{{< callout type="info" >}}
+Have a paid subscription with a provider (e.g., Claude Max/Pro, ChatGPT Plus)? You can use it instead of an API key. See the **[Using a subscription proxy](/docs/subscription-proxy/)** guide.
+{{< /callout >}}
+
 ## Backend types
 
 Click **+ New Backend** to create one. All types share the same dialog:
@@ -63,63 +67,10 @@ For Anthropic's Claude models. Uses the official Anthropic API protocol, which i
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Display name |
-| `url` | No | API base URL. Defaults to `https://api.anthropic.com`. Set this when using a proxy like CLIProxyAPI. |
+| `url` | No | API base URL. Defaults to `https://api.anthropic.com`. Set this when using [a proxy](https://github.com/router-for-me/CLIProxyAPI). |
 | `apiKey` | Yes | Anthropic API key (starts with `sk-ant-`) or proxy API key |
 
 Anthropic doesn't offer STT, TTS, or embedding APIs, so this backend type is used only for LLM inference. For voice and embeddings, add a separate `openai`-type backend pointing at a local service.
-
-### Using your Claude subscription (CLIProxyAPI)
-
-If you have a Claude Max or Pro subscription, you can use your existing account instead of paying separately for API access. This works through [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), a local proxy that translates your subscription's OAuth credentials into a standard Anthropic API.
-
-#### 1. Create the backend
-
-In the Admin UI, create an `anthropic` backend pointing at CLIProxyAPI:
-
-| Field | Value |
-|-------|-------|
-| Name | `Claude (Subscription)` |
-| Type | `anthropic` |
-| URL | `http://cliproxyapi:8317` (Docker) or `http://localhost:8317` (local) |
-| API Key | `sk-magec-local` |
-
-{{< callout type="warning" >}}
-The **URL** field is required. Without it, Magec sends requests to the default Anthropic API (`https://api.anthropic.com`) and authentication will fail.
-{{< /callout >}}
-
-#### 2. Log in with your Claude account
-
-The login command starts a temporary OAuth callback server, so you must **stop the running CLIProxyAPI service first** to free its ports:
-
-```bash
-# Docker — stop, login, restart
-docker compose stop cliproxyapi
-docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
-docker compose up -d cliproxyapi
-
-# Binary
-cliproxyapi --claude-login
-```
-
-The command prints a URL like `https://claude.ai/oauth/authorize?...` — open it in your browser and authorize. After the OAuth callback completes, you'll see a success message. Your credentials are stored in the `cliproxyapi_auth` volume and persist across restarts.
-
-#### 3. Verify
-
-```bash
-curl http://localhost:8317/v1/models \
-  -H "X-Api-Key: sk-magec-local" \
-  -H "anthropic-version: 2023-06-01"
-```
-
-If you see a list of Claude models, CLIProxyAPI is working. You can now assign the backend to any agent.
-
-{{< callout type="info" >}}
-The interactive installer can set up CLIProxyAPI automatically. See [CLIProxyAPI on GitHub](https://github.com/router-for-me/CLIProxyAPI) for full configuration options.
-{{< /callout >}}
-
-{{< callout type="info" >}}
-CLIProxyAPI is a third-party project not affiliated with Anthropic. It uses your existing Claude subscription — you're responsible for ensuring your usage complies with Anthropic's terms of service.
-{{< /callout >}}
 
 ### Google Gemini (`gemini`)
 

--- a/website/content/docs/install-compose-local.md
+++ b/website/content/docs/install-compose-local.md
@@ -190,42 +190,9 @@ These providers only offer LLM — STT, TTS, and embeddings stay local. Create t
 | Anthropic | `anthropic` | `claude-sonnet-4-20250514` |
 | Gemini | `gemini` | `gemini-2.0-flash` |
 
-### Claude subscription (no API key)
+### Provider subscription (no API key)
 
-If you have a Claude Max or Pro subscription, the included CLIProxyAPI service lets you use Claude models without a separate API key.
-
-**Step 1 — Log in with your Claude account.** The login command needs exclusive access to the OAuth callback port, so stop the service first:
-
-```bash
-docker compose stop cliproxyapi
-docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
-docker compose up -d cliproxyapi
-```
-
-Open the URL printed in the terminal, authorize in your browser, and wait for the callback. Your credentials are stored in the `cliproxyapi_auth` volume and persist across restarts.
-
-**Step 2 — Create a backend** in the Admin UI:
-
-| Field | Value |
-|-------|-------|
-| Name | `Claude (Subscription)` |
-| Type | `anthropic` |
-| URL | `http://cliproxyapi:8317` |
-| API Key | `sk-magec-local` |
-
-**Step 3 — Verify.** Assign the backend to an agent and send a test message, or check directly:
-
-```bash
-curl http://localhost:8317/v1/models \
-  -H "X-Api-Key: sk-magec-local" \
-  -H "anthropic-version: 2023-06-01"
-```
-
-The interactive installer can set this up automatically — just answer "yes" when asked about the Claude subscription proxy.
-
-{{< callout type="info" >}}
-CLIProxyAPI is a third-party project. See [AI Backends — CLIProxyAPI](/docs/backends/#using-your-claude-subscription-cliproxyapi) for details.
-{{< /callout >}}
+If you have a paid subscription with a provider (e.g., Claude Max/Pro, ChatGPT Plus), the included CLIProxyAPI service lets you use their models without a separate API key. See the full **[Using a subscription proxy](/docs/subscription-proxy/)** guide for setup instructions.
 
 ## Managing the deployment
 

--- a/website/content/docs/install-compose-local.md
+++ b/website/content/docs/install-compose-local.md
@@ -70,6 +70,7 @@ docker compose up -d
 | **ollama-setup** | Downloads Ollama models on first start, then exits | — |
 | **parakeet** | Speech-to-text (NVIDIA Parakeet) | 5092 |
 | **tts** | Text-to-speech (OpenAI Edge TTS) | 5050 |
+| **cliproxyapi** | Claude subscription proxy ([CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) | 8317 |
 
 ## Set up your first agent
 
@@ -189,6 +190,44 @@ These providers only offer LLM — STT, TTS, and embeddings stay local. Create t
 | Anthropic | `anthropic` | `claude-sonnet-4-20250514` |
 | Gemini | `gemini` | `gemini-2.0-flash` |
 
+### Claude subscription (no API key)
+
+If you have a Claude Max or Pro subscription, the included CLIProxyAPI service lets you use Claude models without a separate API key.
+
+**Step 1 — Log in with your Claude account.** The login command needs exclusive access to the OAuth callback port, so stop the service first:
+
+```bash
+docker compose stop cliproxyapi
+docker compose run --rm --service-ports cliproxyapi \
+  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+docker compose up -d cliproxyapi
+```
+
+Open the URL printed in the terminal, authorize in your browser, and wait for the callback. Your credentials are stored in the `cliproxyapi_auth` volume and persist across restarts.
+
+**Step 2 — Create a backend** in the Admin UI:
+
+| Field | Value |
+|-------|-------|
+| Name | `Claude (Subscription)` |
+| Type | `anthropic` |
+| URL | `http://cliproxyapi:8317` |
+| API Key | `sk-magec-local` |
+
+**Step 3 — Verify.** Assign the backend to an agent and send a test message, or check directly:
+
+```bash
+curl http://localhost:8317/v1/models \
+  -H "X-Api-Key: sk-magec-local" \
+  -H "anthropic-version: 2023-06-01"
+```
+
+The interactive installer can set this up automatically — just answer "yes" when asked about the Claude subscription proxy.
+
+{{< callout type="info" >}}
+CLIProxyAPI is a third-party project. See [AI Backends — CLIProxyAPI](/docs/backends/#using-your-claude-subscription-cliproxyapi) for details.
+{{< /callout >}}
+
 ## Managing the deployment
 
 ```bash
@@ -215,6 +254,7 @@ All data is stored in Docker volumes:
 | `redis_data` | Session memory |
 | `postgres_data` | Long-term memory (pgvector) |
 | `ollama_data` | Downloaded AI models |
+| `cliproxyapi_auth` | CLIProxyAPI OAuth credentials (Claude subscription login) |
 
 Your data survives `docker compose down/up`, image updates, and container recreation. To back up your Magec configuration, copy `data/store.json` from the `magec_data` volume.
 

--- a/website/content/docs/install-compose-local.md
+++ b/website/content/docs/install-compose-local.md
@@ -198,8 +198,7 @@ If you have a Claude Max or Pro subscription, the included CLIProxyAPI service l
 
 ```bash
 docker compose stop cliproxyapi
-docker compose run --rm --service-ports cliproxyapi \
-  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
 docker compose up -d cliproxyapi
 ```
 

--- a/website/content/docs/subscription-proxy.md
+++ b/website/content/docs/subscription-proxy.md
@@ -1,0 +1,129 @@
+---
+title: "Using a subscription proxy"
+---
+
+Some AI providers offer paid subscriptions (e.g., Claude Max/Pro, ChatGPT Plus) that are separate from their API billing. A **subscription proxy** lets you route Magec's API requests through your existing subscription instead of paying for API access separately.
+
+[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) is an open-source proxy that translates subscription OAuth credentials into a standard API. It supports multiple providers and can be used with any Magec backend type that has a configurable `url` field.
+
+## How it works
+
+```
+Magec  ──▶  CLIProxyAPI (localhost:8317)  ──▶  Provider API
+              ▲
+              │ OAuth credentials
+              │ from your subscription
+```
+
+Magec talks to CLIProxyAPI as if it were the provider's official API. CLIProxyAPI authenticates using the OAuth tokens from your subscription login and forwards the request upstream.
+
+## Setting up CLIProxyAPI
+
+### Docker (recommended)
+
+If you used the interactive installer and enabled the subscription proxy, CLIProxyAPI is already running. Otherwise, add it to your `docker-compose.yaml`:
+
+```yaml
+services:
+  cliproxyapi:
+    image: eceasy/cli-proxy-api:latest
+    ports:
+      - "54545:54545"   # OAuth callback (required for login only)
+    volumes:
+      - ./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml
+      - cliproxyapi_auth:/CLIProxyAPI/auth
+    restart: unless-stopped
+
+volumes:
+  cliproxyapi_auth:
+```
+
+Create the config file at `cliproxyapi/config.yaml`:
+
+```yaml
+host: "0.0.0.0"
+port: 8317
+auth-dir: "/CLIProxyAPI/auth"
+api-keys:
+  - "sk-magec-local"
+```
+
+### Binary
+
+Download the latest release from [CLIProxyAPI releases](https://github.com/router-for-me/CLIProxyAPI/releases) and run it directly.
+
+## Logging in to a provider
+
+CLIProxyAPI requires you to authenticate with your provider's subscription account. The login command starts a temporary OAuth callback server, so you must **stop the running CLIProxyAPI service first** to free its ports:
+
+```bash
+docker compose stop cliproxyapi
+docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --<provider-login>
+docker compose up -d cliproxyapi
+```
+
+Replace `--<provider-login>` with the login flag for your provider (see examples below).
+
+The command prints an authorization URL — open it in your browser, authorize, and wait for the callback. Your credentials are stored in the `cliproxyapi_auth` volume and persist across restarts.
+
+## Provider examples
+
+### Claude (Anthropic)
+
+Login flag: `--claude-login` ([docs](https://help.router-for.me/configuration/provider/claude-code.html))
+
+```bash
+docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+```
+
+Then create an `anthropic` backend in the Admin UI:
+
+| Field | Value |
+|-------|-------|
+| Name | `Claude (Subscription)` |
+| Type | `anthropic` |
+| URL | `http://cliproxyapi:8317` (Docker) or `http://localhost:8317` (local) |
+| API Key | `sk-magec-local` |
+
+{{< callout type="warning" >}}
+The **URL** field is required. Without it, Magec sends requests to the default Anthropic API and authentication will fail.
+{{< /callout >}}
+
+### Gemini (Google)
+
+Login flag: `--login` ([docs](https://help.router-for.me/configuration/provider/gemini-cli.html))
+
+```bash
+docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --login
+```
+
+Then create an `openai` backend in the Admin UI (CLIProxyAPI exposes Gemini models through an OpenAI-compatible API):
+
+| Field | Value |
+|-------|-------|
+| Name | `Gemini (Subscription)` |
+| Type | `openai` |
+| URL | `http://cliproxyapi:8317/v1` (Docker) or `http://localhost:8317/v1` (local) |
+| API Key | `sk-magec-local` |
+
+{{< callout type="info" >}}
+CLIProxyAPI supports additional providers like [Codex](https://help.router-for.me/configuration/provider/codex.html) and [Antigravity](https://help.router-for.me/configuration/provider/antigravity.html). See the [full provider list](https://help.router-for.me/) for all available login commands and configuration options.
+{{< /callout >}}
+
+## Verifying the setup
+
+After logging in, check that the proxy is working:
+
+```bash
+curl http://localhost:8317/v1/models -H "X-Api-Key: sk-magec-local"
+```
+
+If you see a list of models, the proxy is ready. Assign the backend to any agent and start chatting.
+
+{{< callout type="info" >}}
+The interactive installer can set up CLIProxyAPI automatically — just answer "yes" when asked about the subscription proxy. See [CLIProxyAPI on GitHub](https://github.com/router-for-me/CLIProxyAPI) for full configuration options.
+{{< /callout >}}
+
+{{< callout type="info" >}}
+CLIProxyAPI is a third-party project not affiliated with any AI provider. You are responsible for ensuring your usage complies with each provider's terms of service.
+{{< /callout >}}

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -129,9 +129,19 @@ theme = 'magec'
     weight = 9
 
   [[menu.docs]]
+    identifier = 'guides'
+    name = 'Guides'
+    weight = 4
+  [[menu.docs]]
+    name = 'Using a subscription proxy'
+    parent = 'guides'
+    url = '/docs/subscription-proxy/'
+    weight = 1
+
+  [[menu.docs]]
     identifier = 'clients'
     name = 'Clients'
-    weight = 4
+    weight = 5
   [[menu.docs]]
     name = 'Overview'
     parent = 'clients'
@@ -171,7 +181,7 @@ theme = 'magec'
   [[menu.docs]]
     identifier = 'reference'
     name = 'Reference'
-    weight = 5
+    weight = 6
   [[menu.docs]]
     name = 'API Reference'
     parent = 'reference'

--- a/website/public/docs/a2a/index.html
+++ b/website/public/docs/a2a/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/admin-password/index.html
+++ b/website/public/docs/admin-password/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/agents/index.html
+++ b/website/public/docs/agents/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>
@@ -305,11 +314,11 @@
 <p>While the <strong>system prompt</strong> defines who the agent is, skills define <strong>what it knows</strong>. An agent with a &ldquo;Return Policy&rdquo; skill and a &ldquo;Product Catalog&rdquo; skill becomes a capable customer support representative without you having to cram everything into one massive prompt.</p>
 <p>Skills are especially powerful when shared across agents. Update a product catalog skill once, and every agent that uses it sees the change.</p>
 <p>For a deeper comparison of when to use skills vs. creating specialized agents, see <a href="/docs/skills-vs-agents/">Skills vs. Agents</a>.</p>
-<h2 id="context-guard-hahahugoshortcode8s4hbhb">
+<h2 id="context-guard-hahahugoshortcode99s4hbhb">
   Context Guard 
 <span class="docs-badge">Experimental</span>
 
-  <a class="heading-anchor" href="#context-guard-hahahugoshortcode8s4hbhb" aria-label="Link to this section">#</a>
+  <a class="heading-anchor" href="#context-guard-hahahugoshortcode99s4hbhb" aria-label="Link to this section">#</a>
 </h2>
 <p>Long conversations eventually hit the model&rsquo;s token limit and fail. Context Guard watches the conversation size and automatically summarizes older messages before that happens. Recent messages stay untouched.</p>
 <p>You set it up per-agent inside the <strong>LLM</strong> section. Two strategies:</p>

--- a/website/public/docs/agents/index.html
+++ b/website/public/docs/agents/index.html
@@ -305,11 +305,11 @@
 <p>While the <strong>system prompt</strong> defines who the agent is, skills define <strong>what it knows</strong>. An agent with a &ldquo;Return Policy&rdquo; skill and a &ldquo;Product Catalog&rdquo; skill becomes a capable customer support representative without you having to cram everything into one massive prompt.</p>
 <p>Skills are especially powerful when shared across agents. Update a product catalog skill once, and every agent that uses it sees the change.</p>
 <p>For a deeper comparison of when to use skills vs. creating specialized agents, see <a href="/docs/skills-vs-agents/">Skills vs. Agents</a>.</p>
-<h2 id="context-guard-hahahugoshortcode9s4hbhb">
+<h2 id="context-guard-hahahugoshortcode8s4hbhb">
   Context Guard 
 <span class="docs-badge">Experimental</span>
 
-  <a class="heading-anchor" href="#context-guard-hahahugoshortcode9s4hbhb" aria-label="Link to this section">#</a>
+  <a class="heading-anchor" href="#context-guard-hahahugoshortcode8s4hbhb" aria-label="Link to this section">#</a>
 </h2>
 <p>Long conversations eventually hit the model&rsquo;s token limit and fail. Context Guard watches the conversation size and automatically summarizes older messages before that happens. Recent messages stay untouched.</p>
 <p>You set it up per-agent inside the <strong>LLM</strong> section. Two strategies:</p>

--- a/website/public/docs/api/index.html
+++ b/website/public/docs/api/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/backends/index.html
+++ b/website/public/docs/backends/index.html
@@ -311,8 +311,7 @@ Key:  (leave empty)
 <p>The login command starts a temporary OAuth callback server, so you must <strong>stop the running CLIProxyAPI service first</strong> to free its ports:</p>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl"><span class="c1"># Docker — stop, login, restart</span>
 </span></span><span class="line"><span class="cl">docker compose stop cliproxyapi
-</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
 </span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
 </span></span><span class="line"><span class="cl">
 </span></span><span class="line"><span class="cl"><span class="c1"># Binary</span>

--- a/website/public/docs/backends/index.html
+++ b/website/public/docs/backends/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>
@@ -159,6 +168,13 @@
 <img src="/img/screenshots/admin-backends.png" alt="Admin UI — Backends" class="screenshot screenshot--desktop">
 
 </div>
+
+
+
+<div class="docs-callout docs-callout--info">
+  Have a paid subscription with a provider (e.g., Claude Max/Pro, ChatGPT Plus)? You can use it instead of an API key. See the <strong><a href="/docs/subscription-proxy/">Using a subscription proxy</a></strong> guide.
+</div>
+
 <h2 id="backend-types">
   Backend types
   <a class="heading-anchor" href="#backend-types" aria-label="Link to this section">#</a>
@@ -251,7 +267,7 @@ Key:  (leave empty)
       <tr>
           <td><code>url</code></td>
           <td>No</td>
-          <td>API base URL. Defaults to <code>https://api.anthropic.com</code>. Set this when using a proxy like CLIProxyAPI.</td>
+          <td>API base URL. Defaults to <code>https://api.anthropic.com</code>. Set this when using <a href="https://github.com/router-for-me/CLIProxyAPI">a proxy</a>.</td>
       </tr>
       <tr>
           <td><code>apiKey</code></td>
@@ -261,84 +277,6 @@ Key:  (leave empty)
   </tbody>
 </table>
 <p>Anthropic doesn&rsquo;t offer STT, TTS, or embedding APIs, so this backend type is used only for LLM inference. For voice and embeddings, add a separate <code>openai</code>-type backend pointing at a local service.</p>
-<h3 id="using-your-claude-subscription-cliproxyapi">
-  Using your Claude subscription (CLIProxyAPI)
-  <a class="heading-anchor" href="#using-your-claude-subscription-cliproxyapi" aria-label="Link to this section">#</a>
-</h3>
-<p>If you have a Claude Max or Pro subscription, you can use your existing account instead of paying separately for API access. This works through <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI</a>, a local proxy that translates your subscription&rsquo;s OAuth credentials into a standard Anthropic API.</p>
-<h4 id="1-create-the-backend">
-  1. Create the backend
-  <a class="heading-anchor" href="#1-create-the-backend" aria-label="Link to this section">#</a>
-</h4>
-<p>In the Admin UI, create an <code>anthropic</code> backend pointing at CLIProxyAPI:</p>
-<table>
-  <thead>
-      <tr>
-          <th>Field</th>
-          <th>Value</th>
-      </tr>
-  </thead>
-  <tbody>
-      <tr>
-          <td>Name</td>
-          <td><code>Claude (Subscription)</code></td>
-      </tr>
-      <tr>
-          <td>Type</td>
-          <td><code>anthropic</code></td>
-      </tr>
-      <tr>
-          <td>URL</td>
-          <td><code>http://cliproxyapi:8317</code> (Docker) or <code>http://localhost:8317</code> (local)</td>
-      </tr>
-      <tr>
-          <td>API Key</td>
-          <td><code>sk-magec-local</code></td>
-      </tr>
-  </tbody>
-</table>
-
-
-
-<div class="docs-callout">
-  The <strong>URL</strong> field is required. Without it, Magec sends requests to the default Anthropic API (<code>https://api.anthropic.com</code>) and authentication will fail.
-</div>
-
-<h4 id="2-log-in-with-your-claude-account">
-  2. Log in with your Claude account
-  <a class="heading-anchor" href="#2-log-in-with-your-claude-account" aria-label="Link to this section">#</a>
-</h4>
-<p>The login command starts a temporary OAuth callback server, so you must <strong>stop the running CLIProxyAPI service first</strong> to free its ports:</p>
-<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl"><span class="c1"># Docker — stop, login, restart</span>
-</span></span><span class="line"><span class="cl">docker compose stop cliproxyapi
-</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
-</span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
-</span></span><span class="line"><span class="cl">
-</span></span><span class="line"><span class="cl"><span class="c1"># Binary</span>
-</span></span><span class="line"><span class="cl">cliproxyapi --claude-login
-</span></span></code></pre></div><p>The command prints a URL like <code>https://claude.ai/oauth/authorize?...</code> — open it in your browser and authorize. After the OAuth callback completes, you&rsquo;ll see a success message. Your credentials are stored in the <code>cliproxyapi_auth</code> volume and persist across restarts.</p>
-<h4 id="3-verify">
-  3. Verify
-  <a class="heading-anchor" href="#3-verify" aria-label="Link to this section">#</a>
-</h4>
-<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">curl http://localhost:8317/v1/models <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;X-Api-Key: sk-magec-local&#34;</span> <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;anthropic-version: 2023-06-01&#34;</span>
-</span></span></code></pre></div><p>If you see a list of Claude models, CLIProxyAPI is working. You can now assign the backend to any agent.</p>
-
-
-
-<div class="docs-callout docs-callout--info">
-  The interactive installer can set up CLIProxyAPI automatically. See <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI on GitHub</a> for full configuration options.
-</div>
-
-
-
-
-<div class="docs-callout docs-callout--info">
-  CLIProxyAPI is a third-party project not affiliated with Anthropic. It uses your existing Claude subscription — you&rsquo;re responsible for ensuring your usage complies with Anthropic&rsquo;s terms of service.
-</div>
-
 <h3 id="google-gemini-gemini">
   Google Gemini (<code>gemini</code>)
   <a class="heading-anchor" href="#google-gemini-gemini" aria-label="Link to this section">#</a>

--- a/website/public/docs/backends/index.html
+++ b/website/public/docs/backends/index.html
@@ -249,13 +249,97 @@ Key:  (leave empty)
           <td>Display name</td>
       </tr>
       <tr>
+          <td><code>url</code></td>
+          <td>No</td>
+          <td>API base URL. Defaults to <code>https://api.anthropic.com</code>. Set this when using a proxy like CLIProxyAPI.</td>
+      </tr>
+      <tr>
           <td><code>apiKey</code></td>
           <td>Yes</td>
-          <td>Anthropic API key (starts with <code>sk-ant-</code>)</td>
+          <td>Anthropic API key (starts with <code>sk-ant-</code>) or proxy API key</td>
       </tr>
   </tbody>
 </table>
 <p>Anthropic doesn&rsquo;t offer STT, TTS, or embedding APIs, so this backend type is used only for LLM inference. For voice and embeddings, add a separate <code>openai</code>-type backend pointing at a local service.</p>
+<h3 id="using-your-claude-subscription-cliproxyapi">
+  Using your Claude subscription (CLIProxyAPI)
+  <a class="heading-anchor" href="#using-your-claude-subscription-cliproxyapi" aria-label="Link to this section">#</a>
+</h3>
+<p>If you have a Claude Max or Pro subscription, you can use your existing account instead of paying separately for API access. This works through <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI</a>, a local proxy that translates your subscription&rsquo;s OAuth credentials into a standard Anthropic API.</p>
+<h4 id="1-create-the-backend">
+  1. Create the backend
+  <a class="heading-anchor" href="#1-create-the-backend" aria-label="Link to this section">#</a>
+</h4>
+<p>In the Admin UI, create an <code>anthropic</code> backend pointing at CLIProxyAPI:</p>
+<table>
+  <thead>
+      <tr>
+          <th>Field</th>
+          <th>Value</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td>Name</td>
+          <td><code>Claude (Subscription)</code></td>
+      </tr>
+      <tr>
+          <td>Type</td>
+          <td><code>anthropic</code></td>
+      </tr>
+      <tr>
+          <td>URL</td>
+          <td><code>http://cliproxyapi:8317</code> (Docker) or <code>http://localhost:8317</code> (local)</td>
+      </tr>
+      <tr>
+          <td>API Key</td>
+          <td><code>sk-magec-local</code></td>
+      </tr>
+  </tbody>
+</table>
+
+
+
+<div class="docs-callout">
+  The <strong>URL</strong> field is required. Without it, Magec sends requests to the default Anthropic API (<code>https://api.anthropic.com</code>) and authentication will fail.
+</div>
+
+<h4 id="2-log-in-with-your-claude-account">
+  2. Log in with your Claude account
+  <a class="heading-anchor" href="#2-log-in-with-your-claude-account" aria-label="Link to this section">#</a>
+</h4>
+<p>The login command starts a temporary OAuth callback server, so you must <strong>stop the running CLIProxyAPI service first</strong> to free its ports:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl"><span class="c1"># Docker — stop, login, restart</span>
+</span></span><span class="line"><span class="cl">docker compose stop cliproxyapi
+</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+</span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
+</span></span><span class="line"><span class="cl">
+</span></span><span class="line"><span class="cl"><span class="c1"># Binary</span>
+</span></span><span class="line"><span class="cl">cliproxyapi --claude-login
+</span></span></code></pre></div><p>The command prints a URL like <code>https://claude.ai/oauth/authorize?...</code> — open it in your browser and authorize. After the OAuth callback completes, you&rsquo;ll see a success message. Your credentials are stored in the <code>cliproxyapi_auth</code> volume and persist across restarts.</p>
+<h4 id="3-verify">
+  3. Verify
+  <a class="heading-anchor" href="#3-verify" aria-label="Link to this section">#</a>
+</h4>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">curl http://localhost:8317/v1/models <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;X-Api-Key: sk-magec-local&#34;</span> <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;anthropic-version: 2023-06-01&#34;</span>
+</span></span></code></pre></div><p>If you see a list of Claude models, CLIProxyAPI is working. You can now assign the backend to any agent.</p>
+
+
+
+<div class="docs-callout docs-callout--info">
+  The interactive installer can set up CLIProxyAPI automatically. See <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI on GitHub</a> for full configuration options.
+</div>
+
+
+
+
+<div class="docs-callout docs-callout--info">
+  CLIProxyAPI is a third-party project not affiliated with Anthropic. It uses your existing Claude subscription — you&rsquo;re responsible for ensuring your usage complies with Anthropic&rsquo;s terms of service.
+</div>
+
 <h3 id="google-gemini-gemini">
   Google Gemini (<code>gemini</code>)
   <a class="heading-anchor" href="#google-gemini-gemini" aria-label="Link to this section">#</a>

--- a/website/public/docs/clients/index.html
+++ b/website/public/docs/clients/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link docs-sidebar__link--active">Overview</a>

--- a/website/public/docs/commands/index.html
+++ b/website/public/docs/commands/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/configuration/index.html
+++ b/website/public/docs/configuration/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/configuration/index.html
+++ b/website/public/docs/configuration/index.html
@@ -193,12 +193,12 @@
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="c"># adminPassword: ${MAGEC_ADMIN_PASSWORD}</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="c"># encryptionKey: ${MAGEC_ENCRYPTION_KEY}</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">voice</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">voice</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">ui</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">enabled</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="w">     </span><span class="c"># Toggle Voice UI and voice routes</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="c"># onnxLibraryPath: /usr/lib/libonnxruntime.so</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">log</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">log</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">level</span><span class="p">:</span><span class="w"> </span><span class="l">info        </span><span class="w"> </span><span class="c"># debug, info, warn, error</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">format</span><span class="p">:</span><span class="w"> </span><span class="l">console    </span><span class="w"> </span><span class="c"># console, json</span><span class="w">
 </span></span></span></code></pre></div><h3 id="server">
@@ -301,7 +301,7 @@
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-yaml" data-lang="yaml"><span class="line"><span class="cl"><span class="nt">server</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">port</span><span class="p">:</span><span class="w"> </span><span class="l">${MAGEC_PORT:-8080}</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">log</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">log</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">level</span><span class="p">:</span><span class="w"> </span><span class="l">${LOG_LEVEL:-info}</span><span class="w">
 </span></span></span></code></pre></div><h2 id="datastorejson--resources">
   data/store.json — Resources

--- a/website/public/docs/context-guard/index.html
+++ b/website/public/docs/context-guard/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/cron/index.html
+++ b/website/public/docs/cron/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/discord/index.html
+++ b/website/public/docs/discord/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/flows/index.html
+++ b/website/public/docs/flows/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/getting-started/index.html
+++ b/website/public/docs/getting-started/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/index.html
+++ b/website/public/docs/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>
@@ -196,6 +205,15 @@
         <li><a href="/docs/secrets/">Secrets</a></li>
         
         <li><a href="/docs/commands/">Commands</a></li>
+        
+      </ul>
+      
+      
+      
+      <h2>Guides</h2>
+      <ul>
+        
+        <li><a href="/docs/subscription-proxy/">Using a subscription proxy</a></li>
         
       </ul>
       

--- a/website/public/docs/install-binary/index.html
+++ b/website/public/docs/install-binary/index.html
@@ -210,11 +210,11 @@
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">port</span><span class="p">:</span><span class="w"> </span><span class="m">8080</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">adminPort</span><span class="p">:</span><span class="w"> </span><span class="m">8081</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">voice</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">voice</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">ui</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">enabled</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">log</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">log</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">level</span><span class="p">:</span><span class="w"> </span><span class="l">info</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">format</span><span class="p">:</span><span class="w"> </span><span class="l">console</span><span class="w">
 </span></span></span></code></pre></div><h2 id="run-magec">
@@ -327,10 +327,10 @@
 </span></span><span class="line"><span class="cl">
 </span></span><span class="line"><span class="cl"><span class="c1"># Long-term memory (requires pgvector)</span>
 </span></span><span class="line"><span class="cl">docker run -d -p 5432:5432 <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -e <span class="nv">POSTGRES_USER</span><span class="o">=</span>magec <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -e <span class="nv">POSTGRES_PASSWORD</span><span class="o">=</span>magec <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -e <span class="nv">POSTGRES_DB</span><span class="o">=</span>magec <span class="se">\
-</span></span></span><span class="line"><span class="cl">  pgvector/pgvector:pg17
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -e <span class="nv">POSTGRES_USER</span><span class="o">=</span>magec <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -e <span class="nv">POSTGRES_PASSWORD</span><span class="o">=</span>magec <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -e <span class="nv">POSTGRES_DB</span><span class="o">=</span>magec <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  pgvector/pgvector:pg17
 </span></span></code></pre></div><p>Then configure in the Admin UI under <strong>Memory</strong>:</p>
 <ul>
 <li>Session: <code>redis://localhost:6379</code></li>

--- a/website/public/docs/install-binary/index.html
+++ b/website/public/docs/install-binary/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/install-compose-local/index.html
+++ b/website/public/docs/install-compose-local/index.html
@@ -182,10 +182,10 @@
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">mkdir magec <span class="o">&amp;&amp;</span> <span class="nb">cd</span> magec
 </span></span><span class="line"><span class="cl">
 </span></span><span class="line"><span class="cl">curl -fsSL https://raw.githubusercontent.com/achetronic/magec/master/docker/compose/docker-compose.yaml <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -o docker-compose.yaml
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -o docker-compose.yaml
 </span></span><span class="line"><span class="cl">
 </span></span><span class="line"><span class="cl">curl -fsSL https://raw.githubusercontent.com/achetronic/magec/master/docker/compose/config.yaml <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -o config.yaml
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -o config.yaml
 </span></span></code></pre></div><h3 id="2-optional-enable-gpu">
   2. (Optional) Enable GPU
   <a class="heading-anchor" href="#2-optional-enable-gpu" aria-label="Link to this section">#</a>
@@ -252,6 +252,11 @@
           <td><strong>tts</strong></td>
           <td>Text-to-speech (OpenAI Edge TTS)</td>
           <td>5050</td>
+      </tr>
+      <tr>
+          <td><strong>cliproxyapi</strong></td>
+          <td>Claude subscription proxy (<a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI</a>)</td>
+          <td>8317</td>
       </tr>
   </tbody>
 </table>
@@ -551,6 +556,56 @@
       </tr>
   </tbody>
 </table>
+<h3 id="claude-subscription-no-api-key">
+  Claude subscription (no API key)
+  <a class="heading-anchor" href="#claude-subscription-no-api-key" aria-label="Link to this section">#</a>
+</h3>
+<p>If you have a Claude Max or Pro subscription, the included CLIProxyAPI service lets you use Claude models without a separate API key.</p>
+<p><strong>Step 1 — Log in with your Claude account.</strong> The login command needs exclusive access to the OAuth callback port, so stop the service first:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker compose stop cliproxyapi
+</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+</span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
+</span></span></code></pre></div><p>Open the URL printed in the terminal, authorize in your browser, and wait for the callback. Your credentials are stored in the <code>cliproxyapi_auth</code> volume and persist across restarts.</p>
+<p><strong>Step 2 — Create a backend</strong> in the Admin UI:</p>
+<table>
+  <thead>
+      <tr>
+          <th>Field</th>
+          <th>Value</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td>Name</td>
+          <td><code>Claude (Subscription)</code></td>
+      </tr>
+      <tr>
+          <td>Type</td>
+          <td><code>anthropic</code></td>
+      </tr>
+      <tr>
+          <td>URL</td>
+          <td><code>http://cliproxyapi:8317</code></td>
+      </tr>
+      <tr>
+          <td>API Key</td>
+          <td><code>sk-magec-local</code></td>
+      </tr>
+  </tbody>
+</table>
+<p><strong>Step 3 — Verify.</strong> Assign the backend to an agent and send a test message, or check directly:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">curl http://localhost:8317/v1/models <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;X-Api-Key: sk-magec-local&#34;</span> <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;anthropic-version: 2023-06-01&#34;</span>
+</span></span></code></pre></div><p>The interactive installer can set this up automatically — just answer &ldquo;yes&rdquo; when asked about the Claude subscription proxy.</p>
+
+
+
+<div class="docs-callout docs-callout--info">
+  CLIProxyAPI is a third-party project. See <a href="/docs/backends/#using-your-claude-subscription-cliproxyapi">AI Backends — CLIProxyAPI</a> for details.
+</div>
+
 <h2 id="managing-the-deployment">
   Managing the deployment
   <a class="heading-anchor" href="#managing-the-deployment" aria-label="Link to this section">#</a>
@@ -594,6 +649,10 @@
       <tr>
           <td><code>ollama_data</code></td>
           <td>Downloaded AI models</td>
+      </tr>
+      <tr>
+          <td><code>cliproxyapi_auth</code></td>
+          <td>CLIProxyAPI OAuth credentials (Claude subscription login)</td>
       </tr>
   </tbody>
 </table>

--- a/website/public/docs/install-compose-local/index.html
+++ b/website/public/docs/install-compose-local/index.html
@@ -563,8 +563,7 @@
 <p>If you have a Claude Max or Pro subscription, the included CLIProxyAPI service lets you use Claude models without a separate API key.</p>
 <p><strong>Step 1 — Log in with your Claude account.</strong> The login command needs exclusive access to the OAuth callback port, so stop the service first:</p>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker compose stop cliproxyapi
-</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
 </span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
 </span></span></code></pre></div><p>Open the URL printed in the terminal, authorize in your browser, and wait for the callback. Your credentials are stored in the <code>cliproxyapi_auth</code> volume and persist across restarts.</p>
 <p><strong>Step 2 — Create a backend</strong> in the Admin UI:</p>

--- a/website/public/docs/install-compose-local/index.html
+++ b/website/public/docs/install-compose-local/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>
@@ -556,55 +565,11 @@
       </tr>
   </tbody>
 </table>
-<h3 id="claude-subscription-no-api-key">
-  Claude subscription (no API key)
-  <a class="heading-anchor" href="#claude-subscription-no-api-key" aria-label="Link to this section">#</a>
+<h3 id="provider-subscription-no-api-key">
+  Provider subscription (no API key)
+  <a class="heading-anchor" href="#provider-subscription-no-api-key" aria-label="Link to this section">#</a>
 </h3>
-<p>If you have a Claude Max or Pro subscription, the included CLIProxyAPI service lets you use Claude models without a separate API key.</p>
-<p><strong>Step 1 — Log in with your Claude account.</strong> The login command needs exclusive access to the OAuth callback port, so stop the service first:</p>
-<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker compose stop cliproxyapi
-</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
-</span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
-</span></span></code></pre></div><p>Open the URL printed in the terminal, authorize in your browser, and wait for the callback. Your credentials are stored in the <code>cliproxyapi_auth</code> volume and persist across restarts.</p>
-<p><strong>Step 2 — Create a backend</strong> in the Admin UI:</p>
-<table>
-  <thead>
-      <tr>
-          <th>Field</th>
-          <th>Value</th>
-      </tr>
-  </thead>
-  <tbody>
-      <tr>
-          <td>Name</td>
-          <td><code>Claude (Subscription)</code></td>
-      </tr>
-      <tr>
-          <td>Type</td>
-          <td><code>anthropic</code></td>
-      </tr>
-      <tr>
-          <td>URL</td>
-          <td><code>http://cliproxyapi:8317</code></td>
-      </tr>
-      <tr>
-          <td>API Key</td>
-          <td><code>sk-magec-local</code></td>
-      </tr>
-  </tbody>
-</table>
-<p><strong>Step 3 — Verify.</strong> Assign the backend to an agent and send a test message, or check directly:</p>
-<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">curl http://localhost:8317/v1/models <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;X-Api-Key: sk-magec-local&#34;</span> <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;anthropic-version: 2023-06-01&#34;</span>
-</span></span></code></pre></div><p>The interactive installer can set this up automatically — just answer &ldquo;yes&rdquo; when asked about the Claude subscription proxy.</p>
-
-
-
-<div class="docs-callout docs-callout--info">
-  CLIProxyAPI is a third-party project. See <a href="/docs/backends/#using-your-claude-subscription-cliproxyapi">AI Backends — CLIProxyAPI</a> for details.
-</div>
-
+<p>If you have a paid subscription with a provider (e.g., Claude Max/Pro, ChatGPT Plus), the included CLIProxyAPI service lets you use their models without a separate API key. See the full <strong><a href="/docs/subscription-proxy/">Using a subscription proxy</a></strong> guide for setup instructions.</p>
 <h2 id="managing-the-deployment">
   Managing the deployment
   <a class="heading-anchor" href="#managing-the-deployment" aria-label="Link to this section">#</a>

--- a/website/public/docs/install-docker/index.html
+++ b/website/public/docs/install-docker/index.html
@@ -166,11 +166,11 @@
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">port</span><span class="p">:</span><span class="w"> </span><span class="m">8080</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">adminPort</span><span class="p">:</span><span class="w"> </span><span class="m">8081</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">voice</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">voice</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">ui</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">enabled</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">
-</span></span></span><span class="line"><span class="cl"><span class="nt">log</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">log</span><span class="p">:</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">level</span><span class="p">:</span><span class="w"> </span><span class="l">info</span><span class="w">
 </span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">format</span><span class="p">:</span><span class="w"> </span><span class="l">console</span><span class="w">
 </span></span></span></code></pre></div><h2 id="2-run-magec">
@@ -178,12 +178,12 @@
   <a class="heading-anchor" href="#2-run-magec" aria-label="Link to this section">#</a>
 </h2>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker run -d <span class="se">\
-</span></span></span><span class="line"><span class="cl">  --name magec <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -p 8080:8080 <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -p 8081:8081 <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -v <span class="k">$(</span><span class="nb">pwd</span><span class="k">)</span>/config.yaml:/app/config.yaml <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -v magec_data:/app/data <span class="se">\
-</span></span></span><span class="line"><span class="cl">  ghcr.io/achetronic/magec:latest
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  --name magec <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -p 8080:8080 <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -p 8081:8081 <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -v <span class="k">$(</span><span class="nb">pwd</span><span class="k">)</span>/config.yaml:/app/config.yaml <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -v magec_data:/app/data <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  ghcr.io/achetronic/magec:latest
 </span></span></code></pre></div><p>That&rsquo;s it. Magec is now running:</p>
 <table>
   <thead>

--- a/website/public/docs/install-docker/index.html
+++ b/website/public/docs/install-docker/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/mcp/index.html
+++ b/website/public/docs/mcp/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/memory/index.html
+++ b/website/public/docs/memory/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/screenshots/index.html
+++ b/website/public/docs/screenshots/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/secrets-advanced/index.html
+++ b/website/public/docs/secrets-advanced/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/secrets/index.html
+++ b/website/public/docs/secrets/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/skills-vs-agents/index.html
+++ b/website/public/docs/skills-vs-agents/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/skills/index.html
+++ b/website/public/docs/skills/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/slack/index.html
+++ b/website/public/docs/slack/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/subscription-proxy/index.html
+++ b/website/public/docs/subscription-proxy/index.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Using a subscription proxy — Magec — Self-hosted Multi-Agent AI Platform</title>
+  <meta name="description" content="Define multiple AI agents, chain them into workflows, connect tools. Voice, Telegram, webhooks, cron. Your server, your rules.">
+  <meta name="theme-color" content="#1c1917">
+  <link rel="icon" type="image/svg+xml" href="/img/logo.svg">
+  <link rel="stylesheet" href="/css/style.css">
+  <meta property="og:title" content="Using a subscription proxy">
+  <meta property="og:description" content="Define multiple AI agents, chain them into workflows, connect tools. Voice, Telegram, webhooks, cron. Your server, your rules.">
+  <meta property="og:type" content="website">
+</head>
+<body>
+  <nav class="nav scrolled">
+  <div class="nav__inner">
+    <a href="/" class="nav__logo">
+      <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <defs><linearGradient id="ng" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs>
+        <circle cx="32" cy="32" r="26" fill="url(#ng)"/>
+        <circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/>
+        <circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="46" cy="30" r="1.2" fill="white" opacity=".6"/>
+        <circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/>
+      </svg>
+      Magec
+    </a>
+    <button class="nav__toggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+    </button>
+    <ul class="nav__links">
+      
+      <li><a href="/#how-it-works" class="nav__link">How it works</a></li>
+      
+      <li><a href="/#what" class="nav__link">Platform</a></li>
+      
+      <li><a href="/#use-cases" class="nav__link">Use cases</a></li>
+      
+      <li><a href="/#screenshots" class="nav__link">Screenshots</a></li>
+      
+      <li><a href="/docs/" class="nav__link">Docs</a></li>
+      
+      <li>
+        <a href="https://github.com/achetronic/magec" class="nav__cta" target="_blank" rel="noopener">
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
+        </a>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+  <main>
+    
+<div class="container">
+  <div class="docs-layout">
+    <aside class="docs-sidebar">
+      
+      
+      <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Getting Started</div>
+        
+        <a href="/docs/install-docker/" class="docs-sidebar__link">Docker Quick Start</a>
+        
+        <a href="/docs/install-compose-local/" class="docs-sidebar__link">Docker Compose</a>
+        
+        <a href="/docs/install-binary/" class="docs-sidebar__link">Binary Install</a>
+        
+        <a href="/docs/configuration/" class="docs-sidebar__link">Configuration</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Security</div>
+        
+        <a href="/docs/admin-password/" class="docs-sidebar__link">Admin Password</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Core Concepts</div>
+        
+        <a href="/docs/agents/" class="docs-sidebar__link">Agents</a>
+        
+        <a href="/docs/flows/" class="docs-sidebar__link">Agentic Flows</a>
+        
+        <a href="/docs/backends/" class="docs-sidebar__link">AI Backends</a>
+        
+        <a href="/docs/memory/" class="docs-sidebar__link">Memory</a>
+        
+        <a href="/docs/mcp/" class="docs-sidebar__link">MCP Tools</a>
+        
+        <a href="/docs/skills/" class="docs-sidebar__link">Skills</a>
+        
+        <a href="/docs/a2a/" class="docs-sidebar__link">A2A Protocol</a>
+        
+        <a href="/docs/secrets/" class="docs-sidebar__link">Secrets</a>
+        
+        <a href="/docs/commands/" class="docs-sidebar__link">Commands</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link docs-sidebar__link--active">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Clients</div>
+        
+        <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>
+        
+        <a href="/docs/voice-ui/" class="docs-sidebar__link">Voice UI</a>
+        
+        <a href="/docs/telegram/" class="docs-sidebar__link">Telegram</a>
+        
+        <a href="/docs/slack/" class="docs-sidebar__link">Slack</a>
+        
+        <a href="/docs/discord/" class="docs-sidebar__link">Discord</a>
+        
+        <a href="/docs/webhooks/" class="docs-sidebar__link">Webhooks</a>
+        
+        <a href="/docs/cron/" class="docs-sidebar__link">Cron</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Reference</div>
+        
+        <a href="/docs/api/" class="docs-sidebar__link">API Reference</a>
+        
+        <a href="/docs/voice-system/" class="docs-sidebar__link">Voice System</a>
+        
+        <a href="/docs/secrets-advanced/" class="docs-sidebar__link">Advanced Secrets</a>
+        
+        <a href="/docs/skills-vs-agents/" class="docs-sidebar__link">Skills vs. Agents</a>
+        
+        <a href="/docs/screenshots/" class="docs-sidebar__link">Screenshots</a>
+        
+      </div>
+      
+      
+    </aside>
+    <div class="docs-content">
+      <button class="docs-sidebar-toggle btn btn--ghost">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        Navigation
+      </button>
+      <h1>Using a subscription proxy</h1>
+      <p>Some AI providers offer paid subscriptions (e.g., Claude Max/Pro, ChatGPT Plus) that are separate from their API billing. A <strong>subscription proxy</strong> lets you route Magec&rsquo;s API requests through your existing subscription instead of paying for API access separately.</p>
+<p><a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI</a> is an open-source proxy that translates subscription OAuth credentials into a standard API. It supports multiple providers and can be used with any Magec backend type that has a configurable <code>url</code> field.</p>
+<h2 id="how-it-works">
+  How it works
+  <a class="heading-anchor" href="#how-it-works" aria-label="Link to this section">#</a>
+</h2>
+<pre tabindex="0"><code>Magec  ──▶  CLIProxyAPI (localhost:8317)  ──▶  Provider API
+              ▲
+              │ OAuth credentials
+              │ from your subscription
+</code></pre><p>Magec talks to CLIProxyAPI as if it were the provider&rsquo;s official API. CLIProxyAPI authenticates using the OAuth tokens from your subscription login and forwards the request upstream.</p>
+<h2 id="setting-up-cliproxyapi">
+  Setting up CLIProxyAPI
+  <a class="heading-anchor" href="#setting-up-cliproxyapi" aria-label="Link to this section">#</a>
+</h2>
+<h3 id="docker-recommended">
+  Docker (recommended)
+  <a class="heading-anchor" href="#docker-recommended" aria-label="Link to this section">#</a>
+</h3>
+<p>If you used the interactive installer and enabled the subscription proxy, CLIProxyAPI is already running. Otherwise, add it to your <code>docker-compose.yaml</code>:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-yaml" data-lang="yaml"><span class="line"><span class="cl"><span class="nt">services</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">cliproxyapi</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l">eceasy/cli-proxy-api:latest</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">ports</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">      </span>- <span class="s2">&#34;54545:54545&#34;</span><span class="w">   </span><span class="c"># OAuth callback (required for login only)</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">volumes</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">      </span>- <span class="l">./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">      </span>- <span class="l">cliproxyapi_auth:/CLIProxyAPI/auth</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">    </span><span class="nt">restart</span><span class="p">:</span><span class="w"> </span><span class="l">unless-stopped</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">volumes</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">  </span><span class="nt">cliproxyapi_auth</span><span class="p">:</span><span class="w">
+</span></span></span></code></pre></div><p>Create the config file at <code>cliproxyapi/config.yaml</code>:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-yaml" data-lang="yaml"><span class="line"><span class="cl"><span class="nt">host</span><span class="p">:</span><span class="w"> </span><span class="s2">&#34;0.0.0.0&#34;</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">port</span><span class="p">:</span><span class="w"> </span><span class="m">8317</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">auth-dir</span><span class="p">:</span><span class="w"> </span><span class="s2">&#34;/CLIProxyAPI/auth&#34;</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w"></span><span class="nt">api-keys</span><span class="p">:</span><span class="w">
+</span></span></span><span class="line"><span class="cl"><span class="w">  </span>- <span class="s2">&#34;sk-magec-local&#34;</span><span class="w">
+</span></span></span></code></pre></div><h3 id="binary">
+  Binary
+  <a class="heading-anchor" href="#binary" aria-label="Link to this section">#</a>
+</h3>
+<p>Download the latest release from <a href="https://github.com/router-for-me/CLIProxyAPI/releases">CLIProxyAPI releases</a> and run it directly.</p>
+<h2 id="logging-in-to-a-provider">
+  Logging in to a provider
+  <a class="heading-anchor" href="#logging-in-to-a-provider" aria-label="Link to this section">#</a>
+</h2>
+<p>CLIProxyAPI requires you to authenticate with your provider&rsquo;s subscription account. The login command starts a temporary OAuth callback server, so you must <strong>stop the running CLIProxyAPI service first</strong> to free its ports:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker compose stop cliproxyapi
+</span></span><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --&lt;provider-login&gt;
+</span></span><span class="line"><span class="cl">docker compose up -d cliproxyapi
+</span></span></code></pre></div><p>Replace <code>--&lt;provider-login&gt;</code> with the login flag for your provider (see examples below).</p>
+<p>The command prints an authorization URL — open it in your browser, authorize, and wait for the callback. Your credentials are stored in the <code>cliproxyapi_auth</code> volume and persist across restarts.</p>
+<h2 id="provider-examples">
+  Provider examples
+  <a class="heading-anchor" href="#provider-examples" aria-label="Link to this section">#</a>
+</h2>
+<h3 id="claude-anthropic">
+  Claude (Anthropic)
+  <a class="heading-anchor" href="#claude-anthropic" aria-label="Link to this section">#</a>
+</h3>
+<p>Login flag: <code>--claude-login</code> (<a href="https://help.router-for.me/configuration/provider/claude-code.html">docs</a>)</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login
+</span></span></code></pre></div><p>Then create an <code>anthropic</code> backend in the Admin UI:</p>
+<table>
+  <thead>
+      <tr>
+          <th>Field</th>
+          <th>Value</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td>Name</td>
+          <td><code>Claude (Subscription)</code></td>
+      </tr>
+      <tr>
+          <td>Type</td>
+          <td><code>anthropic</code></td>
+      </tr>
+      <tr>
+          <td>URL</td>
+          <td><code>http://cliproxyapi:8317</code> (Docker) or <code>http://localhost:8317</code> (local)</td>
+      </tr>
+      <tr>
+          <td>API Key</td>
+          <td><code>sk-magec-local</code></td>
+      </tr>
+  </tbody>
+</table>
+
+
+
+<div class="docs-callout">
+  The <strong>URL</strong> field is required. Without it, Magec sends requests to the default Anthropic API and authentication will fail.
+</div>
+
+<h3 id="gemini-google">
+  Gemini (Google)
+  <a class="heading-anchor" href="#gemini-google" aria-label="Link to this section">#</a>
+</h3>
+<p>Login flag: <code>--login</code> (<a href="https://help.router-for.me/configuration/provider/gemini-cli.html">docs</a>)</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --login
+</span></span></code></pre></div><p>Then create an <code>openai</code> backend in the Admin UI (CLIProxyAPI exposes Gemini models through an OpenAI-compatible API):</p>
+<table>
+  <thead>
+      <tr>
+          <th>Field</th>
+          <th>Value</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td>Name</td>
+          <td><code>Gemini (Subscription)</code></td>
+      </tr>
+      <tr>
+          <td>Type</td>
+          <td><code>openai</code></td>
+      </tr>
+      <tr>
+          <td>URL</td>
+          <td><code>http://cliproxyapi:8317/v1</code> (Docker) or <code>http://localhost:8317/v1</code> (local)</td>
+      </tr>
+      <tr>
+          <td>API Key</td>
+          <td><code>sk-magec-local</code></td>
+      </tr>
+  </tbody>
+</table>
+
+
+
+<div class="docs-callout docs-callout--info">
+  CLIProxyAPI supports additional providers like <a href="https://help.router-for.me/configuration/provider/codex.html">Codex</a> and <a href="https://help.router-for.me/configuration/provider/antigravity.html">Antigravity</a>. See the <a href="https://help.router-for.me/">full provider list</a> for all available login commands and configuration options.
+</div>
+
+<h2 id="verifying-the-setup">
+  Verifying the setup
+  <a class="heading-anchor" href="#verifying-the-setup" aria-label="Link to this section">#</a>
+</h2>
+<p>After logging in, check that the proxy is working:</p>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">curl http://localhost:8317/v1/models -H <span class="s2">&#34;X-Api-Key: sk-magec-local&#34;</span>
+</span></span></code></pre></div><p>If you see a list of models, the proxy is ready. Assign the backend to any agent and start chatting.</p>
+
+
+
+<div class="docs-callout docs-callout--info">
+  The interactive installer can set up CLIProxyAPI automatically — just answer &ldquo;yes&rdquo; when asked about the subscription proxy. See <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI on GitHub</a> for full configuration options.
+</div>
+
+
+
+
+<div class="docs-callout docs-callout--info">
+  CLIProxyAPI is a third-party project not affiliated with any AI provider. You are responsible for ensuring your usage complies with each provider&rsquo;s terms of service.
+</div>
+
+
+    </div>
+  </div>
+</div>
+
+  </main>
+  <div id="lightbox" class="lightbox">
+  <button class="lightbox__close" aria-label="Close">✕</button>
+  <img id="lightbox-img" src="" alt="">
+</div>
+
+  <footer class="footer">
+  <div class="container">
+    <div class="footer__inner">
+      <div class="footer__brand">
+        <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+          <defs><linearGradient id="fg" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs>
+          <circle cx="32" cy="32" r="26" fill="url(#fg)"/>
+          <circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/>
+          <circle cx="38" cy="38" r="2" fill="white" opacity=".75"/>
+        </svg>
+        Magec · Apache 2.0
+      </div>
+      <ul class="footer__links">
+        <li><a href="https://github.com/achetronic/magec" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="/docs/">Docs</a></li>
+        <li><a href="https://github.com/achetronic/magec/issues" target="_blank" rel="noopener">Issues</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+  <script type="module" src="/js/main.js"></script>
+</body>
+</html>

--- a/website/public/docs/telegram/index.html
+++ b/website/public/docs/telegram/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/voice-system/index.html
+++ b/website/public/docs/voice-system/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/voice-ui/index.html
+++ b/website/public/docs/voice-ui/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/docs/webhooks/index.html
+++ b/website/public/docs/webhooks/index.html
@@ -241,13 +241,13 @@
 </code></pre><p>Authentication uses the client&rsquo;s token as a Bearer token:</p>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl"><span class="c1"># Command mode — body is ignored</span>
 </span></span><span class="line"><span class="cl">curl -X POST http://localhost:8080/api/v1/webhooks/YOUR_WEBHOOK_ID <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -H <span class="s2">&#34;Authorization: Bearer mgc_your_token&#34;</span>
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;Authorization: Bearer mgc_your_token&#34;</span>
 </span></span><span class="line"><span class="cl">
 </span></span><span class="line"><span class="cl"><span class="c1"># Passthrough mode — body contains the prompt</span>
 </span></span><span class="line"><span class="cl">curl -X POST http://localhost:8080/api/v1/webhooks/YOUR_WEBHOOK_ID <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -H <span class="s2">&#34;Authorization: Bearer mgc_your_token&#34;</span> <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -H <span class="s2">&#34;Content-Type: application/json&#34;</span> <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -d <span class="s1">&#39;{&#34;prompt&#34;: &#34;Analyze this error: connection timeout on service X&#34;}&#39;</span>
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;Authorization: Bearer mgc_your_token&#34;</span> <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;Content-Type: application/json&#34;</span> <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -d <span class="s1">&#39;{&#34;prompt&#34;: &#34;Analyze this error: connection timeout on service X&#34;}&#39;</span>
 </span></span></code></pre></div><p>The agent processes the request synchronously and the response is returned in the HTTP response body. This makes webhooks easy to integrate with any system that can make HTTP requests and read responses.</p>
 <h2 id="example-integrations">
   Example integrations
@@ -270,9 +270,9 @@
 </h3>
 <p>Forward alerts from Prometheus, Grafana, or any monitoring tool:</p>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">curl -X POST http://magec:8080/api/v1/webhooks/alert-handler <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -H <span class="s2">&#34;Authorization: Bearer mgc_...&#34;</span> <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -H <span class="s2">&#34;Content-Type: application/json&#34;</span> <span class="se">\
-</span></span></span><span class="line"><span class="cl">  -d <span class="s1">&#39;{&#34;prompt&#34;: &#34;Critical alert: CPU usage above 90% on prod-web-01 for 10 minutes. Analyze possible causes and suggest remediation.&#34;}&#39;</span>
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;Authorization: Bearer mgc_...&#34;</span> <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -H <span class="s2">&#34;Content-Type: application/json&#34;</span> <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span>  -d <span class="s1">&#39;{&#34;prompt&#34;: &#34;Critical alert: CPU usage above 90% on prod-web-01 for 10 minutes. Analyze possible causes and suggest remediation.&#34;}&#39;</span>
 </span></span></code></pre></div><h3 id="form-processing">
   Form processing
   <a class="heading-anchor" href="#form-processing" aria-label="Link to this section">#</a>

--- a/website/public/docs/webhooks/index.html
+++ b/website/public/docs/webhooks/index.html
@@ -107,6 +107,15 @@
       
       
       <div class="docs-sidebar__group">
+        <div class="docs-sidebar__label">Guides</div>
+        
+        <a href="/docs/subscription-proxy/" class="docs-sidebar__link">Using a subscription proxy</a>
+        
+      </div>
+      
+      
+      
+      <div class="docs-sidebar__group">
         <div class="docs-sidebar__label">Clients</div>
         
         <a href="/docs/clients/" class="docs-sidebar__link">Overview</a>

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta name="generator" content="Hugo 0.155.3"><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+	<meta name="generator" content="Hugo 0.147.1"><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Magec — Self-hosted Multi-Agent AI Platform</title>

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -60,6 +60,8 @@
   </url><url>
     <loc>http://localhost:1313/docs/telegram/</loc>
   </url><url>
+    <loc>http://localhost:1313/docs/subscription-proxy/</loc>
+  </url><url>
     <loc>http://localhost:1313/docs/voice-system/</loc>
   </url><url>
     <loc>http://localhost:1313/docs/voice-ui/</loc>


### PR DESCRIPTION
## Summary

- **Fix**: Anthropic backend was ignoring the `url` field, always sending requests to `https://api.anthropic.com`. Added `BaseURL: backend.URL` to the Anthropic backend constructor — this is required for CLIProxyAPI (or any Anthropic-compatible proxy) to work.
- **Feature**: Integrate [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) so users with a Claude Max/Pro subscription can use Claude models without a separate API key.
- **DX**: Add `make docs` / `make docs-stop` to run the documentation site via Docker (no local Hugo install needed).

## Changes

### Bug fix (`server/agent/agent.go`)

The Anthropic backend constructor was not passing `BaseURL` from the backend config, so the `url` field configured in the Admin UI was silently ignored. All requests went to the default Anthropic API regardless of what URL was set. This one-line fix is the critical change that makes CLIProxyAPI (and any custom Anthropic endpoint) work.

### CLIProxyAPI integration

- **`docker/compose/docker-compose.yaml`** — Added `cliproxyapi` service and `cliproxyapi_auth` volume
- **`docker/compose/cliproxyapi/config.yaml`** — Default proxy config (port 8317, `auth-dir`, API key `sk-magec-local`)
- **`scripts/install.sh`** — Full wizard integration: prompts user to enable CLIProxyAPI, generates config, preconfigures backend and default agent, shows login instructions on the success screen

### Documentation

- **`website/content/docs/backends.md`** — Added `url` field to Anthropic backend table; new CLIProxyAPI section with step-by-step setup (create backend → login → verify)
- **`website/content/docs/install-compose-local.md`** — Added CLIProxyAPI to the services table, new "Claude subscription" section, added `cliproxyapi_auth` to data persistence table

### Developer experience (`Makefile`)

- `make docs` — Runs Hugo in a Docker container on port 1313 with live reload
- `make docs-stop` — Stops the documentation container

## Test plan

- [ ] Run `bash scripts/install.sh`, select Docker Compose + cloud-only, enable CLIProxyAPI
- [ ] Verify generated `docker-compose.yaml` has correct volume mount (`/CLIProxyAPI/config.yaml`)
- [ ] Verify generated `cliproxyapi/config.yaml` includes `auth-dir`
- [ ] Run `docker compose stop cliproxyapi` then `docker compose run --rm --service-ports cliproxyapi /CLIProxyAPI/CLIProxyAPI --no-browser --claude-login` — complete OAuth flow
- [ ] Run `docker compose up -d cliproxyapi` — verify service starts with `1 auth entries`
- [ ] Create Anthropic backend with URL `http://cliproxyapi:8317` — send a message to the agent and verify Claude responds
- [ ] Verify `make docs` starts Hugo on http://localhost:1313
