### PR TITLE
fix: accept snake_case JSON on POST /agent/run and /run_sse (fixes #26)

### DIFF
--- a/docs/PR_VERIFICATION_GITHUB_26_CURL.md
+++ b/docs/PR_VERIFICATION_GITHUB_26_CURL.md
@@ -1,0 +1,145 @@
+# Manual verification: GitHub #26 (`snake_case` on `POST /agent/run`)
+
+Reproducible **curl + jq** flow with **environment variables** (no hard-coded UUIDs).  
+（繁中說明：變數占位、可重現的驗收步驟，供 PR 描述或本地對照。）
+
+下列步驟使用**變數占位**，可在 bash／Git Bash／WSL 一鍵複製調整。需已啟動 Magec（預設 user API `:8080`、admin API `:8081`），並有一個可連線的 **OpenAI 相容**後端（例如 Ollama：`http://localhost:11434/v1`；若 Magec 在 Docker 內，後端 URL 常用 `http://host.docker.internal:11434/v1`）。
+
+**前置：**安裝 `curl` 與 `jq`。
+
+```bash
+# --- 依你的環境修改 ---
+export MAGE_USER_BASE="http://127.0.0.1:8080"   # User API（/api/v1/agent/...）
+export MAGE_ADMIN_BASE="http://127.0.0.1:8081"  # Admin API（/api/v1/admin/...）
+export ADMIN_PASSWORD="your-admin-password"     # 對應 config server.adminPassword
+
+# 後端：OpenAI 相容 Base URL（勿省略 /v1）
+export LLM_BASE_URL="http://host.docker.internal:11434/v1"
+
+# Ollama 上實際存在的模型名
+export LLM_MODEL="qwen3:8b"
+
+# 之後由 API 填入
+export CLIENT_TOKEN=""
+export BACKEND_ID=""
+export AGENT_ID=""
+export CLIENT_ID=""
+```
+
+## 1) 取得 Direct client 的 token 與 id
+
+若你已有一個 `type=direct` 的 client，從列表抄 `id` 與 `token` 即可：
+
+```bash
+curl -sS "${MAGE_ADMIN_BASE}/api/v1/admin/clients" \
+  -H "Authorization: Bearer ${ADMIN_PASSWORD}" | jq .
+```
+
+手動設定（或由 jq 篩選第一個 direct）：
+
+```bash
+CLIENT_ID="$(curl -sS "${MAGE_ADMIN_BASE}/api/v1/admin/clients" \
+  -H "Authorization: Bearer ${ADMIN_PASSWORD}" | jq -r '.[] | select(.type=="direct") | .id' | head -1)"
+
+CLIENT_TOKEN="$(curl -sS "${MAGE_ADMIN_BASE}/api/v1/admin/clients" \
+  -H "Authorization: Bearer ${ADMIN_PASSWORD}" | jq -r --arg id "$CLIENT_ID" '.[] | select(.id==$id) | .token')"
+```
+
+## 2) 建立 Backend（OpenAI 相容）
+
+```bash
+BACKEND_ID="$(
+  curl -sS -X POST "${MAGE_ADMIN_BASE}/api/v1/admin/backends" \
+    -H "Authorization: Bearer ${ADMIN_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n \
+      --arg url "$LLM_BASE_URL" \
+      '{name:"verify-gh26-backend",type:"openai",url:$url}')" \
+  | jq -r '.id'
+)"
+echo "BACKEND_ID=${BACKEND_ID}"
+```
+
+## 3) 建立 Agent（綁定上述 backend + 模型）
+
+```bash
+AGENT_ID="$(
+  curl -sS -X POST "${MAGE_ADMIN_BASE}/api/v1/admin/agents" \
+    -H "Authorization: Bearer ${ADMIN_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n \
+      --arg b "$BACKEND_ID" \
+      --arg m "$LLM_MODEL" \
+      '{name:"verify-gh26-agent",llm:{backend:$b,model:$m}}')" \
+  | jq -r '.id'
+)"
+echo "AGENT_ID=${AGENT_ID}"
+```
+
+## 4) 讓該 client 能使用此 agent（`allowedAgents`）
+
+```bash
+curl -sS -X PUT "${MAGE_ADMIN_BASE}/api/v1/admin/clients/${CLIENT_ID}" \
+  -H "Authorization: Bearer ${ADMIN_PASSWORD}" \
+  -H "Content-Type: application/json" \
+  -d "$(curl -sS "${MAGE_ADMIN_BASE}/api/v1/admin/clients/${CLIENT_ID}" \
+        -H "Authorization: Bearer ${ADMIN_PASSWORD}" \
+      | jq --arg a "$AGENT_ID" '.allowedAgents = [$a]')" | jq .
+```
+
+（若你希望保留原有 allowed 清單，請自行改 jq 合併陣列。）
+
+## 5) 確認 `list-apps` 可見該 agent
+
+```bash
+curl -sS "${MAGE_USER_BASE}/api/v1/agent/list-apps" \
+  -H "Authorization: Bearer ${CLIENT_TOKEN}" | jq .
+# 預期：JSON 陣列中含 "${AGENT_ID}"
+```
+
+## 6) 建立 session（ADK 慣例：先建 session 再 run）
+
+自訂 user／session 字串（僅需全程一致）：
+
+```bash
+export GH26_USER="gh26-verify-user"
+export GH26_SESSION="gh26-verify-session"
+
+curl -sS -X POST \
+  "${MAGE_USER_BASE}/api/v1/agent/apps/${AGENT_ID}/users/${GH26_USER}/sessions/${GH26_SESSION}" \
+  -H "Authorization: Bearer ${CLIENT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{}' | jq .
+# 預期：HTTP 200
+```
+
+## 7) 驗收重點：`POST /run` 僅送 **snake_case**（#26）
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" --max-time 120 -X POST \
+  "${MAGE_USER_BASE}/api/v1/agent/run" \
+  -H "Authorization: Bearer ${CLIENT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n \
+    --arg app "$AGENT_ID" \
+    --arg u "$GH26_USER" \
+    --arg s "$GH26_SESSION" \
+    '{app_name:$app,user_id:$u,session_id:$s,new_message:{role:"user",parts:[{text:"Reply with exactly one word: pong"}]}}')"
+```
+
+**預期：**HTTP **200**，回應 JSON 內模型文字含 **`pong`**（或語意等同之回覆）。
+
+若此時仍出現 **`session … not found`**，且已確認步驟 6 為 200、步驟 7 的 `app_name`／`user_id`／`session_id` 與步驟 6 路徑一致，則再對照本 PR 的 `RunAgentJSONNormalize` 是否已套在 `/api/v1/agent/` 鏈上。
+
+## 8) 自動化測試（無需真 LLM）
+
+```bash
+cd server
+go test ./middleware/ -run 'RunAgentJSONNormalize|Normalize' -count=1 -v
+```
+
+---
+
+## 選用：同流程驗 `run_sse`
+
+將步驟 7 的 URL 改為 `"${MAGE_USER_BASE}/api/v1/agent/run_sse"`，並依客戶端能力處理 `text/event-stream`（本文件略）。

--- a/server/api/user/adk_swagger.go
+++ b/server/api/user/adk_swagger.go
@@ -6,11 +6,11 @@ package user
 
 // RunAgent executes an agent synchronously.
 // @Summary      Run agent
-// @Description  Send a message to an agent and receive the full response. The app_name is the agent ID.
+// @Description  Send a message to an agent and receive the full response. Preferred JSON keys are camelCase (appName, userId, sessionId, newMessage) per Google ADK. For compatibility (see GitHub #26), snake_case (app_name, user_id, session_id, new_message) is also accepted and normalized server-side. appName must be the agent id / UUID from GET /agent/list-apps.
 // @Tags         agent
 // @Accept       json
 // @Produce      json
-// @Param        body  body      object  true  "Run request with app_name, user_id, session_id, and new_message"
+// @Param        body  body      RunAgentRequest  true  "ADK run request"
 // @Success      200   {object}  object  "Agent response"
 // @Failure      400   {object}  ErrorResponse
 // @Failure      404   {object}  ErrorResponse
@@ -20,11 +20,11 @@ func (h *Handler) RunAgent() {}
 
 // RunAgentSSE executes an agent with streaming via Server-Sent Events.
 // @Summary      Run agent (SSE streaming)
-// @Description  Send a message to an agent and receive the response streamed as Server-Sent Events.
+// @Description  Same JSON body as POST /agent/run (camelCase preferred; snake_case accepted and normalized). Response is text/event-stream (SSE).
 // @Tags         agent
 // @Accept       json
 // @Produce      text/event-stream
-// @Param        body  body      object  true  "Run request with app_name, user_id, session_id, and new_message"
+// @Param        body  body      RunAgentRequest  true  "ADK run request"
 // @Success      200   {object}  object  "SSE event stream"
 // @Failure      400   {object}  ErrorResponse
 // @Failure      404   {object}  ErrorResponse

--- a/server/api/user/docs/userapi_docs.go
+++ b/server/api/user/docs/userapi_docs.go
@@ -787,7 +787,7 @@ const docTemplateuserapi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the full response. The app_name is the agent ID.",
+                "description": "Send a message to an agent and receive the full response. Preferred JSON keys are camelCase (appName, userId, sessionId, newMessage) per Google ADK. For compatibility (see GitHub #26), snake_case (app_name, user_id, session_id, new_message) is also accepted and normalized server-side. appName must be the agent id / UUID from GET /agent/list-apps.",
                 "consumes": [
                     "application/json"
                 ],
@@ -800,12 +800,12 @@ const docTemplateuserapi = `{
                 "summary": "Run agent",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
@@ -838,7 +838,7 @@ const docTemplateuserapi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the response streamed as Server-Sent Events.",
+                "description": "Same JSON body as POST /agent/run (camelCase preferred; snake_case accepted and normalized). Response is text/event-stream (SSE).",
                 "consumes": [
                     "application/json"
                 ],
@@ -851,12 +851,12 @@ const docTemplateuserapi = `{
                 "summary": "Run agent (SSE streaming)",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
@@ -1361,6 +1361,59 @@ const docTemplateuserapi = `{
                 "error": {
                     "type": "string",
                     "example": "resource not found"
+                }
+            }
+        },
+        "user.RunAgentMessage": {
+            "type": "object",
+            "properties": {
+                "parts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.RunAgentMessagePart"
+                    }
+                },
+                "role": {
+                    "type": "string",
+                    "example": "user"
+                }
+            }
+        },
+        "user.RunAgentMessagePart": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "example": "Hello"
+                }
+            }
+        },
+        "user.RunAgentRequest": {
+            "type": "object",
+            "properties": {
+                "appName": {
+                    "type": "string",
+                    "example": "my-agent-id"
+                },
+                "newMessage": {
+                    "$ref": "#/definitions/user.RunAgentMessage"
+                },
+                "sessionId": {
+                    "type": "string",
+                    "example": "conversation-001"
+                },
+                "stateDelta": {
+                    "description": "StateDelta is optional session state patch (ADK).",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "streaming": {
+                    "description": "Streaming is optional; primarily used by ADK internals.",
+                    "type": "boolean"
+                },
+                "userId": {
+                    "type": "string",
+                    "example": "default_user"
                 }
             }
         },

--- a/server/api/user/docs/userapi_swagger.json
+++ b/server/api/user/docs/userapi_swagger.json
@@ -784,7 +784,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the full response. The app_name is the agent ID.",
+                "description": "Send a message to an agent and receive the full response. Preferred JSON keys are camelCase (appName, userId, sessionId, newMessage) per Google ADK. For compatibility (see GitHub #26), snake_case (app_name, user_id, session_id, new_message) is also accepted and normalized server-side. appName must be the agent id / UUID from GET /agent/list-apps.",
                 "consumes": [
                     "application/json"
                 ],
@@ -797,12 +797,12 @@
                 "summary": "Run agent",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
@@ -835,7 +835,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the response streamed as Server-Sent Events.",
+                "description": "Same JSON body as POST /agent/run (camelCase preferred; snake_case accepted and normalized). Response is text/event-stream (SSE).",
                 "consumes": [
                     "application/json"
                 ],
@@ -848,12 +848,12 @@
                 "summary": "Run agent (SSE streaming)",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
@@ -1358,6 +1358,59 @@
                 "error": {
                     "type": "string",
                     "example": "resource not found"
+                }
+            }
+        },
+        "user.RunAgentMessage": {
+            "type": "object",
+            "properties": {
+                "parts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.RunAgentMessagePart"
+                    }
+                },
+                "role": {
+                    "type": "string",
+                    "example": "user"
+                }
+            }
+        },
+        "user.RunAgentMessagePart": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "example": "Hello"
+                }
+            }
+        },
+        "user.RunAgentRequest": {
+            "type": "object",
+            "properties": {
+                "appName": {
+                    "type": "string",
+                    "example": "my-agent-id"
+                },
+                "newMessage": {
+                    "$ref": "#/definitions/user.RunAgentMessage"
+                },
+                "sessionId": {
+                    "type": "string",
+                    "example": "conversation-001"
+                },
+                "stateDelta": {
+                    "description": "StateDelta is optional session state patch (ADK).",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "streaming": {
+                    "description": "Streaming is optional; primarily used by ADK internals.",
+                    "type": "boolean"
+                },
+                "userId": {
+                    "type": "string",
+                    "example": "default_user"
                 }
             }
         },

--- a/server/api/user/docs/userapi_swagger.yaml
+++ b/server/api/user/docs/userapi_swagger.yaml
@@ -135,6 +135,43 @@ definitions:
         example: resource not found
         type: string
     type: object
+  user.RunAgentMessage:
+    properties:
+      parts:
+        items:
+          $ref: '#/definitions/user.RunAgentMessagePart'
+        type: array
+      role:
+        example: user
+        type: string
+    type: object
+  user.RunAgentMessagePart:
+    properties:
+      text:
+        example: Hello
+        type: string
+    type: object
+  user.RunAgentRequest:
+    properties:
+      appName:
+        example: my-agent-id
+        type: string
+      newMessage:
+        $ref: '#/definitions/user.RunAgentMessage'
+      sessionId:
+        example: conversation-001
+        type: string
+      stateDelta:
+        additionalProperties: true
+        description: StateDelta is optional session state patch (ADK).
+        type: object
+      streaming:
+        description: Streaming is optional; primarily used by ADK internals.
+        type: boolean
+      userId:
+        example: default_user
+        type: string
+    type: object
   user.SpeechRequest:
     properties:
       input:
@@ -680,15 +717,18 @@ paths:
     post:
       consumes:
       - application/json
-      description: Send a message to an agent and receive the full response. The app_name
-        is the agent ID.
+      description: 'Send a message to an agent and receive the full response. Preferred
+        JSON keys are camelCase (appName, userId, sessionId, newMessage) per Google
+        ADK. For compatibility (see GitHub #26), snake_case (app_name, user_id, session_id,
+        new_message) is also accepted and normalized server-side. appName must be
+        the agent id / UUID from GET /agent/list-apps.'
       parameters:
-      - description: Run request with app_name, user_id, session_id, and new_message
+      - description: ADK run request
         in: body
         name: body
         required: true
         schema:
-          type: object
+          $ref: '#/definitions/user.RunAgentRequest'
       produces:
       - application/json
       responses:
@@ -713,15 +753,15 @@ paths:
     post:
       consumes:
       - application/json
-      description: Send a message to an agent and receive the response streamed as
-        Server-Sent Events.
+      description: Same JSON body as POST /agent/run (camelCase preferred; snake_case
+        accepted and normalized). Response is text/event-stream (SSE).
       parameters:
-      - description: Run request with app_name, user_id, session_id, and new_message
+      - description: ADK run request
         in: body
         name: body
         required: true
         schema:
-          type: object
+          $ref: '#/definitions/user.RunAgentRequest'
       produces:
       - text/event-stream
       responses:

--- a/server/main.go
+++ b/server/main.go
@@ -170,7 +170,9 @@ func main() {
 		middleware.ConversationRecorderSSE(filtered, executor, dataStore, "user"),
 		executor, dataStore, "user",
 	)
-	httpMux.Handle("/api/v1/agent/", userRecorded)
+	// Accept snake_case JSON on /run and /run_sse (GitHub #26); ADK expects camelCase.
+	agentHandler := middleware.RunAgentJSONNormalize(userRecorded)
+	httpMux.Handle("/api/v1/agent/", agentHandler)
 	httpMux.Handle("/api/v1/voice/", newVoiceHandler(dataStore, agentRouter))
 
 	// A2A protocol endpoints (global discovery + per-agent card + JSON-RPC invoke)

--- a/server/middleware/runagent_normalize.go
+++ b/server/middleware/runagent_normalize.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// RunAgentJSONNormalize rewrites POST /agent/run and /agent/run_sse JSON bodies so that
+// snake_case keys used in older clients and bug reports (GitHub #26) are accepted:
+// app_name→appName, user_id→userId, session_id→sessionId, new_message→newMessage,
+// state_delta→stateDelta. CamelCase keys win if both are present.
+// The ADK REST layer only unmarshals camelCase; without this, session lookup fails with
+// "session not found" even when the session exists.
+func RunAgentJSONNormalize(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+		path := r.URL.Path
+		isRun := strings.HasSuffix(path, "/run")
+		isRunSSE := strings.HasSuffix(path, "/run_sse")
+		if !isRun && !isRunSSE {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil || len(body) == 0 {
+			if len(body) == 0 {
+				r.Body = io.NopCloser(bytes.NewReader(nil))
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		out, changed, normErr := normalizeRunAgentJSONBody(body)
+		if normErr != nil {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			r.ContentLength = int64(len(body))
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !changed {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(out))
+		r.ContentLength = int64(len(out))
+		r.Header.Set("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func normalizeRunAgentJSONBody(body []byte) (out []byte, changed bool, err error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, false, err
+	}
+	if len(m) == 0 {
+		return body, false, nil
+	}
+
+	aliases := []struct {
+		snake, camel string
+	}{
+		{"app_name", "appName"},
+		{"user_id", "userId"},
+		{"session_id", "sessionId"},
+		{"new_message", "newMessage"},
+		{"state_delta", "stateDelta"},
+	}
+
+	for _, a := range aliases {
+		snakeRaw, hasSnake := m[a.snake]
+		if !hasSnake {
+			continue
+		}
+		if _, hasCamel := m[a.camel]; !hasCamel {
+			m[a.camel] = snakeRaw
+			changed = true
+		}
+		delete(m, a.snake)
+		changed = true
+	}
+
+	if !changed {
+		return body, false, nil
+	}
+
+	out, err = json.Marshal(m)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}

--- a/server/middleware/runagent_normalize_http_test.go
+++ b/server/middleware/runagent_normalize_http_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRunAgentJSONNormalize_ChainToNextHandler verifies GitHub #26 end-to-end on the wire:
+// clients send snake_case; the handler that receives the request after this middleware
+// must see camelCase keys that ADK unmarshaling expects.
+func TestRunAgentJSONNormalize_ChainToNextHandler(t *testing.T) {
+	snakePayload := `{"app_name":"agent-uuid-1","user_id":"u1","session_id":"sess-gh26","new_message":{"role":"user","parts":[{"text":"hi"}]}}`
+
+	for _, path := range []string{"/api/v1/agent/run", "/api/v1/agent/run_sse"} {
+		t.Run(path, func(t *testing.T) {
+			var got []byte
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				got, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			h := RunAgentJSONNormalize(next)
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(snakePayload))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("unexpected status %d", rec.Code)
+			}
+
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(got, &m); err != nil {
+				t.Fatalf("downstream body not JSON: %v\n%s", err, string(got))
+			}
+			if _, ok := m["app_name"]; ok {
+				t.Fatal("downstream must not contain app_name (GitHub #26)")
+			}
+			if string(m["appName"]) != `"agent-uuid-1"` {
+				t.Fatalf("appName: got %s", string(m["appName"]))
+			}
+			if string(m["userId"]) != `"u1"` {
+				t.Fatalf("userId: got %s", string(m["userId"]))
+			}
+			if string(m["sessionId"]) != `"sess-gh26"` {
+				t.Fatalf("sessionId: got %s", string(m["sessionId"]))
+			}
+			if _, ok := m["new_message"]; ok {
+				t.Fatal("downstream must not contain new_message")
+			}
+			if _, ok := m["newMessage"]; !ok {
+				t.Fatal("downstream must contain newMessage")
+			}
+		})
+	}
+}
+
+// Other POST paths must not rewrite JSON (only /run and /run_sse).
+func TestRunAgentJSONNormalize_OtherPathsPassThrough(t *testing.T) {
+	body := `{"app_name":"x","user_id":"y"}`
+	var got []byte
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	h := RunAgentJSONNormalize(next)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/other", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	if !bytes.Equal(got, []byte(body)) {
+		t.Fatalf("expected pass-through, got %s", string(got))
+	}
+}
+
+func TestRunAgentJSONNormalize_GETPassesThrough(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := RunAgentJSONNormalize(next)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/run", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+}

--- a/server/middleware/runagent_normalize_test.go
+++ b/server/middleware/runagent_normalize_test.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeRunAgentJSONBody_SnakeToCamel(t *testing.T) {
+	in := []byte(`{"app_name":"agent-1","user_id":"u","session_id":"sess","new_message":{"role":"user","parts":[{"text":"hi"}]}}`)
+	out, changed, err := normalizeRunAgentJSONBody(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected changed")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["app_name"]; ok {
+		t.Fatal("app_name should be removed")
+	}
+	if m["appName"] != "agent-1" {
+		t.Fatalf("appName: got %v", m["appName"])
+	}
+	if m["userId"] != "u" {
+		t.Fatalf("userId: got %v", m["userId"])
+	}
+	if m["sessionId"] != "sess" {
+		t.Fatalf("sessionId: got %v", m["sessionId"])
+	}
+}
+
+func TestNormalizeRunAgentJSONBody_CamelPreferred(t *testing.T) {
+	in := []byte(`{"appName":"from-camel","app_name":"from-snake","userId":"u","sessionId":"s","newMessage":{"role":"user","parts":[]}}`)
+	out, changed, err := normalizeRunAgentJSONBody(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected changed (snake keys dropped)")
+	}
+	var m map[string]interface{}
+	json.Unmarshal(out, &m)
+	if m["appName"] != "from-camel" {
+		t.Fatalf("want camel appName preserved, got %v", m["appName"])
+	}
+}
+
+func TestNormalizeRunAgentJSONBody_AlreadyCamel(t *testing.T) {
+	in := []byte(`{"appName":"a","userId":"u","sessionId":"s","newMessage":{}}`)
+	out, changed, err := normalizeRunAgentJSONBody(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatalf("should not change, got %s", string(out))
+	}
+}


### PR DESCRIPTION
## Problem (Issue #26)

Some API clients send **snake_case** JSON to:

- `POST /api/v1/agent/run`
- `POST /api/v1/agent/run_sse`

Example keys: `app_name`, `user_id`, `session_id`, `new_message`, `state_delta`.

The Google ADK REST layer only unmarshals **camelCase** (`appName`, `userId`, …). As a result, fields stay empty, routing breaks, and operators can see misleading **`session not found`** responses **even after** a successful `POST .../sessions/...` create.

Root discussion: [#26](https://github.com/achetronic/magec/issues/26).

## Solution

Add **`RunAgentJSONNormalize`** middleware on the `/api/v1/agent/` handler chain. It rewrites the JSON body to camelCase **before** the ADK handler runs.

Rules:

- Only affects **`POST`** paths ending with **`/run`** or **`/run_sse`**.
- If both snake_case and camelCase keys are present, **camelCase wins** (explicit client intent).
- Other agent routes are untouched.

## Files (high level)

| Area | Path |
|------|------|
| Middleware | `server/middleware/runagent_normalize.go` |
| Wire-up | `server/main.go` |
| Unit tests | `server/middleware/runagent_normalize_test.go` |
| HTTP chain test (body seen by next handler) | `server/middleware/runagent_normalize_http_test.go` |
| User API docs / Swagger | `server/api/user/adk_swagger.go`, `server/api/user/docs/*` |

**Optional follow-up in the same tree** (can drop or split if you want a minimal merge):

- `server/agent/agent.go` — warn when `sessionProvider` does not match any memory provider (helps avoid “Redis vs in-memory” confusion mentioned in #26 discussion).

## How to verify

**1) Automated (no LLM / no agent setup)**

```bash
cd server
go test ./middleware/ -run 'RunAgentJSONNormalize|Normalize' -count=1 -v
```

**2) Manual E2E** (OpenAI-compatible backend + agent + session create + `run`):

- Reproducible **curl + jq** with **placeholders only**: `docs/PR_VERIFICATION_GITHUB_26_CURL.md` in this branch.

We also validated snake_case `POST /run` end-to-end against a local Ollama backend after creating the ADK session (200 + expected model output).

## Scope / risk

- **Low risk**: request shaping only; no change to ADK internals.
- **Rollback**: revert middleware registration in `main.go` and remove the middleware package.

## Maintainer notes

- **Telegram / PR #22**: this branch may include related work in our mirror; for **upstream** I am happy to **re-open a smaller PR** with **only** #26 files if you prefer (say the word and I will force-push a trimmed branch).

## Contributor (Taiwan)

- I am **Taiwanese** — I live in **Taiwan** (台灣).
- My **native language is Traditional Chinese (zh-TW)**; this description is in English so maintainers worldwide can review it. If wording sounds odd, please ask and I will rephrase quickly.

## Repository / fork (why not MagecAnalysis)

GitHub needs the PR **head** to share commit history with `achetronic/magec`, or the diff becomes the whole tree. Our separate mirror **`seamusrex/MagecAnalysis`** documents experiments and patches but is **not** a fork of upstream, so this PR is opened from the standard fork **`seamusrex/magec`** (branch `fix/gh26-snake-case-json`). Same author; mirror: https://github.com/seamusrex/MagecAnalysis

Thank you for Magec and for triaging #26.