### PR TITLE
feat: Add recursive snake_case to camelCase normalization for ADK RES…

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -65,6 +65,7 @@ magec/
 │   │   ├── middleware.go       # AccessLog (httpsnoop), CORS, ClientAuth, AdminAuth (rate-limited)
 │   │   ├── recorder.go         # ConversationRecorder + ConversationRecorderSSE (dual-perspective)
 │   │   ├── flowfilter.go       # Flow response filtering by responseAgent
+│   │   ├── normalize.go        # SnakeCaseNormalize: recursive snake_case→camelCase for /run and /run_sse
 │   │   ├── sessionensure.go    # Idempotent session creation (prevents overwriting ContextGuard state)
 │   │   └── sessionstate.go     # Seeds outputKey values into session state for {{agent.output:key}} resolution
 │   ├── clients/                # Client type registry + runtime
@@ -235,6 +236,7 @@ log:
 - **Dual-perspective conversation recording**: Middleware chains recorder twice: "admin" perspective (all events, before FlowResponseFilter) and "user" perspective (filtered, after). Each conversation has a `ParentID` linking the pair
 - **Store dual-copy pattern**: Store maintains `rawData` (unexpanded, with `${VAR}` refs) and `data` (env-expanded). API responses use raw data, runtime uses expanded. Secret values injected as env vars before expansion
 - **Session middleware**: `SessionEnsure` prevents overwriting existing sessions (protects ContextGuard summaries). `SessionStateSeed` injects empty outputKey values so `{{agent.output:key}}` references in flow agent prompts resolve correctly
+- **SnakeCaseNormalize middleware**: Intercepts POST `/run` and `/run_sse`, recursively converts all snake_case JSON keys to camelCase before ADK processes the request. ADK uses `DisallowUnknownFields()` so any unconverted snake_case key causes a 400. Conversion is generic (not a fixed key list) — handles all nesting levels including `genai.Part` fields like `inlineData`, `mimeType`, `functionCall`. When both forms coexist in the same object, camelCase wins. Single-word keys are never modified. Placed outermost in the middleware chain (before ConversationRecorder)
 - **InstructionProvider pattern**: Agents use `InstructionProvider` instead of static `Instruction` strings to bypass ADK's built-in `{variable}` substitution (which conflicts with curly braces in prompts, JSON examples, scripts, etc). Magec resolves its own `{{agent.output:key}}` pattern from session state inside the provider. Plain `{text}` in prompts is never touched
 - **Flow wrapAgent pattern**: Same agent can appear in multiple flow steps — `wrapAgent()` creates uniquely-named delegate agents to satisfy ADK's single-parent constraint
 
@@ -346,6 +348,7 @@ GPU section commented out by default. Users who want cloud providers create diff
 16. **ContextGuard `safeSplitIndex`**: When splitting conversation history for summarization, the split point is adjusted to avoid orphaning Anthropic `tool_result` blocks.
 17. **Store env var expansion**: All store fields support `${VAR}` syntax. Secrets are injected as env vars (`os.Setenv`) before the store is expanded, so secrets can be referenced in backend URLs, bot tokens, etc.
 18. **Voice API routes always registered**: STT/TTS proxy endpoints are available regardless of Voice UI toggle, since Telegram/Discord/Slack clients need them.
+19. **ADK REST API accepts both camelCase and snake_case**: The `SnakeCaseNormalize` middleware converts snake_case keys recursively before ADK sees the request. This applies only to `/run` and `/run_sse` — the only ADK endpoints with multi-word JSON body fields. Session create/get/delete use single-word body fields (`state`, `events`) or path parameters only.
 
 ## Testing
 

--- a/.agents/DECISIONS.md
+++ b/.agents/DECISIONS.md
@@ -448,3 +448,28 @@ ADK's `InjectSessionState` automatically replaces `{anything}` in agent instruct
 **Do not**: Use ADK's static `Instruction` field on `llmagent.Config`. Always use `InstructionProvider` via `makeInstructionProvider()`. Do not introduce new substitution patterns — `{{agent.output:key}}` is the only one.
 
 **Files**: `server/agent/agent.go` (`makeInstructionProvider`, `stateVarRegex`).
+
+---
+
+## 20. Recursive snake_case→camelCase normalization for ADK REST API
+
+**Date**: 2026-04-09
+**Status**: Implemented
+
+ADK's REST decoder calls `json.Decoder.DisallowUnknownFields()`, which rejects any JSON key that doesn't match a struct tag exactly. All ADK and genai JSON tags are camelCase (`appName`, `sessionId`, `inlineData`, `mimeType`, etc.) with zero exceptions. API clients sending snake_case keys get a 400.
+
+**Solution**: `SnakeCaseNormalize` middleware intercepts POST `/run` and `/run_sse`, parses the JSON body, and recursively converts all snake_case keys to camelCase at every nesting level. Generic `snakeToCamel` conversion (not a hardcoded key list) so it handles any current and future fields without maintenance.
+
+**Key behaviors**:
+- When both `app_name` and `appName` coexist in the same object, camelCase wins (explicit client intent)
+- Single-word keys (`text`, `role`, `parts`, `data`) are never modified
+- If the body is not valid JSON or already all camelCase, the original bytes pass through unchanged
+- `Content-Length` is updated after rewriting
+
+**Scope**: Only `/run` and `/run_sse` — the only ADK endpoints with multi-word JSON body fields. Session create uses single-word fields (`state`, `events`). Session/artifact paths use URL parameters (already snake_case by ADK design).
+
+**Middleware position**: Outermost in the chain, before `ConversationRecorder`, so all downstream middlewares see the normalized camelCase body.
+
+**Do not**: Use a fixed key list (fragile, misses nested genai fields). Do not normalize non-`/run` paths (unnecessary, could interfere with other handlers). Do not modify response bodies — only request normalization.
+
+**Files**: `server/middleware/normalize.go`, `server/main.go` (wiring).

--- a/server/api/admin/docs/docs.go
+++ b/server/api/admin/docs/docs.go
@@ -2597,6 +2597,62 @@ const docTemplate = `{
                 }
             }
         },
+        "/skills/{id}/package": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "Uploads a ZIP or tar.gz archive containing a SKILL.md and optional reference files",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Upload skill package",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Package archive (ZIP or tar.gz)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/store.Skill"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/skills/{id}/references": {
             "post": {
                 "security": [
@@ -2943,6 +2999,12 @@ const docTemplate = `{
                 "apiKey": {
                     "type": "string"
                 },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2962,6 +3024,12 @@ const docTemplate = `{
             "properties": {
                 "backend": {
                     "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "model": {
                     "type": "string"
@@ -3039,6 +3107,9 @@ const docTemplate = `{
             "properties": {
                 "enabled": {
                     "type": "boolean"
+                },
+                "maxTokens": {
+                    "type": "integer"
                 },
                 "maxTurns": {
                     "type": "integer"
@@ -3167,8 +3238,14 @@ const docTemplate = `{
                 "botToken": {
                     "type": "string"
                 },
-                "guildId": {
+                "defaultAgent": {
                     "type": "string"
+                },
+                "responseMode": {
+                    "type": "string"
+                },
+                "threadHistoryLimit": {
+                    "type": "integer"
                 }
             }
         },
@@ -3366,8 +3443,14 @@ const docTemplate = `{
                 "botToken": {
                     "type": "string"
                 },
+                "defaultAgent": {
+                    "type": "string"
+                },
                 "responseMode": {
                     "type": "string"
+                },
+                "threadHistoryLimit": {
+                    "type": "integer"
                 }
             }
         },
@@ -3404,6 +3487,9 @@ const docTemplate = `{
                     }
                 },
                 "botToken": {
+                    "type": "string"
+                },
+                "defaultAgent": {
                     "type": "string"
                 },
                 "responseMode": {

--- a/server/api/admin/docs/swagger.json
+++ b/server/api/admin/docs/swagger.json
@@ -2594,6 +2594,62 @@
                 }
             }
         },
+        "/skills/{id}/package": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "Uploads a ZIP or tar.gz archive containing a SKILL.md and optional reference files",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Upload skill package",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Skill ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Package archive (ZIP or tar.gz)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/store.Skill"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/skills/{id}/references": {
             "post": {
                 "security": [
@@ -2940,6 +2996,12 @@
                 "apiKey": {
                     "type": "string"
                 },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2959,6 +3021,12 @@
             "properties": {
                 "backend": {
                     "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "model": {
                     "type": "string"
@@ -3036,6 +3104,9 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
+                },
+                "maxTokens": {
+                    "type": "integer"
                 },
                 "maxTurns": {
                     "type": "integer"
@@ -3164,8 +3235,14 @@
                 "botToken": {
                     "type": "string"
                 },
-                "guildId": {
+                "defaultAgent": {
                     "type": "string"
+                },
+                "responseMode": {
+                    "type": "string"
+                },
+                "threadHistoryLimit": {
+                    "type": "integer"
                 }
             }
         },
@@ -3363,8 +3440,14 @@
                 "botToken": {
                     "type": "string"
                 },
+                "defaultAgent": {
+                    "type": "string"
+                },
                 "responseMode": {
                     "type": "string"
+                },
+                "threadHistoryLimit": {
+                    "type": "integer"
                 }
             }
         },
@@ -3401,6 +3484,9 @@
                     }
                 },
                 "botToken": {
+                    "type": "string"
+                },
+                "defaultAgent": {
                     "type": "string"
                 },
                 "responseMode": {

--- a/server/api/admin/docs/swagger.yaml
+++ b/server/api/admin/docs/swagger.yaml
@@ -136,6 +136,10 @@ definitions:
     properties:
       apiKey:
         type: string
+      headers:
+        additionalProperties:
+          type: string
+        type: object
       id:
         type: string
       name:
@@ -149,6 +153,10 @@ definitions:
     properties:
       backend:
         type: string
+      headers:
+        additionalProperties:
+          type: string
+        type: object
       model:
         type: string
     type: object
@@ -199,6 +207,8 @@ definitions:
     properties:
       enabled:
         type: boolean
+      maxTokens:
+        type: integer
       maxTurns:
         type: integer
       strategy:
@@ -283,8 +293,12 @@ definitions:
         type: array
       botToken:
         type: string
-      guildId:
+      defaultAgent:
         type: string
+      responseMode:
+        type: string
+      threadHistoryLimit:
+        type: integer
     type: object
   store.FlowDefinition:
     properties:
@@ -413,8 +427,12 @@ definitions:
         type: string
       botToken:
         type: string
+      defaultAgent:
+        type: string
       responseMode:
         type: string
+      threadHistoryLimit:
+        type: integer
     type: object
   store.TTSRef:
     properties:
@@ -438,6 +456,8 @@ definitions:
           type: integer
         type: array
       botToken:
+        type: string
+      defaultAgent:
         type: string
       responseMode:
         type: string
@@ -2105,6 +2125,43 @@ paths:
       security:
       - AdminAuth: []
       summary: Update skill
+      tags:
+      - skills
+  /skills/{id}/package:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Uploads a ZIP or tar.gz archive containing a SKILL.md and optional
+        reference files
+      parameters:
+      - description: Skill ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Package archive (ZIP or tar.gz)
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/store.Skill'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/admin.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/admin.ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: Upload skill package
       tags:
       - skills
   /skills/{id}/references:

--- a/server/api/user/adk_swagger.go
+++ b/server/api/user/adk_swagger.go
@@ -4,14 +4,43 @@ package user
 // These endpoints are served by the Google ADK router, not by our handlers.
 // The annotations here exist solely to include them in the Swagger spec.
 
+// RunAgentRequest is the body for /run and /run_sse. Both camelCase and
+// snake_case field names are accepted (snake_case is converted automatically).
+type RunAgentRequest struct {
+	AppName    string              `json:"appName" example:"550e8400-e29b-41d4-a716-446655440000"`
+	UserID     string              `json:"userId" example:"user1"`
+	SessionID  string              `json:"sessionId" example:"f47ac10b-58cc-4372-a567-0e02b2c3d479"`
+	NewMessage RunAgentMessage     `json:"newMessage"`
+	Streaming  bool                `json:"streaming,omitempty" example:"false"`
+	StateDelta map[string]interface{} `json:"stateDelta,omitempty"`
+}
+
+// RunAgentMessage is the user message sent to an agent.
+type RunAgentMessage struct {
+	Role  string                `json:"role" example:"user"`
+	Parts []RunAgentMessagePart `json:"parts"`
+}
+
+// RunAgentMessagePart is a single part of a message (text or inline data).
+type RunAgentMessagePart struct {
+	Text       string                 `json:"text,omitempty" example:"Hello!"`
+	InlineData *RunAgentInlineData    `json:"inlineData,omitempty"`
+}
+
+// RunAgentInlineData represents a binary blob sent inline (base64-encoded).
+type RunAgentInlineData struct {
+	MIMEType string `json:"mimeType" example:"image/png"`
+	Data     string `json:"data" example:"iVBORw0KGgo..."`
+}
+
 // RunAgent executes an agent synchronously.
-// @Summary      Run agent
-// @Description  Send a message to an agent and receive the full response. The app_name is the agent ID.
+// @Summary      Run agent (accepts both camelCase and snake_case)
+// @Description  Send a message to an agent and receive the full response. The appName is the agent ID. Both camelCase (canonical) and snake_case field names are accepted at every nesting level — a normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler.
 // @Tags         agent
 // @Accept       json
 // @Produce      json
-// @Param        body  body      object  true  "Run request with app_name, user_id, session_id, and new_message"
-// @Success      200   {object}  object  "Agent response"
+// @Param        body  body      RunAgentRequest  true  "ADK run request"
+// @Success      200   {array}   object           "Array of agent response events"
 // @Failure      400   {object}  ErrorResponse
 // @Failure      404   {object}  ErrorResponse
 // @Security     BearerAuth
@@ -19,13 +48,13 @@ package user
 func (h *Handler) RunAgent() {}
 
 // RunAgentSSE executes an agent with streaming via Server-Sent Events.
-// @Summary      Run agent (SSE streaming)
-// @Description  Send a message to an agent and receive the response streamed as Server-Sent Events.
+// @Summary      Run agent SSE (accepts both camelCase and snake_case)
+// @Description  Send a message to an agent and receive the response streamed as Server-Sent Events. Both camelCase (canonical) and snake_case field names are accepted at every nesting level — a normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler.
 // @Tags         agent
 // @Accept       json
 // @Produce      text/event-stream
-// @Param        body  body      object  true  "Run request with app_name, user_id, session_id, and new_message"
-// @Success      200   {object}  object  "SSE event stream"
+// @Param        body  body      RunAgentRequest  true  "ADK run request"
+// @Success      200   {object}  object           "SSE event stream"
 // @Failure      400   {object}  ErrorResponse
 // @Failure      404   {object}  ErrorResponse
 // @Security     BearerAuth

--- a/server/api/user/docs/userapi_docs.go
+++ b/server/api/user/docs/userapi_docs.go
@@ -787,7 +787,7 @@ const docTemplateuserapi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the full response. The app_name is the agent ID.",
+                "description": "Send a message to an agent and receive the full response. The appName is the agent ID. Both camelCase (canonical) and snake_case field names are accepted at every nesting level — a normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler.",
                 "consumes": [
                     "application/json"
                 ],
@@ -797,23 +797,26 @@ const docTemplateuserapi = `{
                 "tags": [
                     "agent"
                 ],
-                "summary": "Run agent",
+                "summary": "Run agent (accepts both camelCase and snake_case)",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Agent response",
+                        "description": "Array of agent response events",
                         "schema": {
-                            "type": "object"
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
                         }
                     },
                     "400": {
@@ -838,7 +841,7 @@ const docTemplateuserapi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the response streamed as Server-Sent Events.",
+                "description": "Send a message to an agent and receive the response streamed as Server-Sent Events. Both camelCase (canonical) and snake_case field names are accepted at every nesting level — a normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler.",
                 "consumes": [
                     "application/json"
                 ],
@@ -848,15 +851,15 @@ const docTemplateuserapi = `{
                 "tags": [
                     "agent"
                 ],
-                "summary": "Run agent (SSE streaming)",
+                "summary": "Run agent SSE (accepts both camelCase and snake_case)",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
@@ -1361,6 +1364,74 @@ const docTemplateuserapi = `{
                 "error": {
                     "type": "string",
                     "example": "resource not found"
+                }
+            }
+        },
+        "user.RunAgentInlineData": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string",
+                    "example": "iVBORw0KGgo..."
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "image/png"
+                }
+            }
+        },
+        "user.RunAgentMessage": {
+            "type": "object",
+            "properties": {
+                "parts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.RunAgentMessagePart"
+                    }
+                },
+                "role": {
+                    "type": "string",
+                    "example": "user"
+                }
+            }
+        },
+        "user.RunAgentMessagePart": {
+            "type": "object",
+            "properties": {
+                "inlineData": {
+                    "$ref": "#/definitions/user.RunAgentInlineData"
+                },
+                "text": {
+                    "type": "string",
+                    "example": "Hello!"
+                }
+            }
+        },
+        "user.RunAgentRequest": {
+            "type": "object",
+            "properties": {
+                "appName": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "newMessage": {
+                    "$ref": "#/definitions/user.RunAgentMessage"
+                },
+                "sessionId": {
+                    "type": "string",
+                    "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                },
+                "stateDelta": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "streaming": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "userId": {
+                    "type": "string",
+                    "example": "user1"
                 }
             }
         },

--- a/server/api/user/docs/userapi_swagger.json
+++ b/server/api/user/docs/userapi_swagger.json
@@ -784,7 +784,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the full response. The app_name is the agent ID.",
+                "description": "Send a message to an agent and receive the full response. The appName is the agent ID. Both camelCase (canonical) and snake_case field names are accepted at every nesting level — a normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler.",
                 "consumes": [
                     "application/json"
                 ],
@@ -794,23 +794,26 @@
                 "tags": [
                     "agent"
                 ],
-                "summary": "Run agent",
+                "summary": "Run agent (accepts both camelCase and snake_case)",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Agent response",
+                        "description": "Array of agent response events",
                         "schema": {
-                            "type": "object"
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
                         }
                     },
                     "400": {
@@ -835,7 +838,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Send a message to an agent and receive the response streamed as Server-Sent Events.",
+                "description": "Send a message to an agent and receive the response streamed as Server-Sent Events. Both camelCase (canonical) and snake_case field names are accepted at every nesting level — a normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler.",
                 "consumes": [
                     "application/json"
                 ],
@@ -845,15 +848,15 @@
                 "tags": [
                     "agent"
                 ],
-                "summary": "Run agent (SSE streaming)",
+                "summary": "Run agent SSE (accepts both camelCase and snake_case)",
                 "parameters": [
                     {
-                        "description": "Run request with app_name, user_id, session_id, and new_message",
+                        "description": "ADK run request",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/user.RunAgentRequest"
                         }
                     }
                 ],
@@ -1358,6 +1361,74 @@
                 "error": {
                     "type": "string",
                     "example": "resource not found"
+                }
+            }
+        },
+        "user.RunAgentInlineData": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string",
+                    "example": "iVBORw0KGgo..."
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "image/png"
+                }
+            }
+        },
+        "user.RunAgentMessage": {
+            "type": "object",
+            "properties": {
+                "parts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.RunAgentMessagePart"
+                    }
+                },
+                "role": {
+                    "type": "string",
+                    "example": "user"
+                }
+            }
+        },
+        "user.RunAgentMessagePart": {
+            "type": "object",
+            "properties": {
+                "inlineData": {
+                    "$ref": "#/definitions/user.RunAgentInlineData"
+                },
+                "text": {
+                    "type": "string",
+                    "example": "Hello!"
+                }
+            }
+        },
+        "user.RunAgentRequest": {
+            "type": "object",
+            "properties": {
+                "appName": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "newMessage": {
+                    "$ref": "#/definitions/user.RunAgentMessage"
+                },
+                "sessionId": {
+                    "type": "string",
+                    "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                },
+                "stateDelta": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "streaming": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "userId": {
+                    "type": "string",
+                    "example": "user1"
                 }
             }
         },

--- a/server/api/user/docs/userapi_swagger.yaml
+++ b/server/api/user/docs/userapi_swagger.yaml
@@ -135,6 +135,53 @@ definitions:
         example: resource not found
         type: string
     type: object
+  user.RunAgentInlineData:
+    properties:
+      data:
+        example: iVBORw0KGgo...
+        type: string
+      mimeType:
+        example: image/png
+        type: string
+    type: object
+  user.RunAgentMessage:
+    properties:
+      parts:
+        items:
+          $ref: '#/definitions/user.RunAgentMessagePart'
+        type: array
+      role:
+        example: user
+        type: string
+    type: object
+  user.RunAgentMessagePart:
+    properties:
+      inlineData:
+        $ref: '#/definitions/user.RunAgentInlineData'
+      text:
+        example: Hello!
+        type: string
+    type: object
+  user.RunAgentRequest:
+    properties:
+      appName:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      newMessage:
+        $ref: '#/definitions/user.RunAgentMessage'
+      sessionId:
+        example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+        type: string
+      stateDelta:
+        additionalProperties: true
+        type: object
+      streaming:
+        example: false
+        type: boolean
+      userId:
+        example: user1
+        type: string
+    type: object
   user.SpeechRequest:
     properties:
       input:
@@ -680,22 +727,26 @@ paths:
     post:
       consumes:
       - application/json
-      description: Send a message to an agent and receive the full response. The app_name
-        is the agent ID.
+      description: Send a message to an agent and receive the full response. The appName
+        is the agent ID. Both camelCase (canonical) and snake_case field names are
+        accepted at every nesting level — a normalization middleware converts snake_case
+        keys to camelCase recursively before the request reaches the ADK handler.
       parameters:
-      - description: Run request with app_name, user_id, session_id, and new_message
+      - description: ADK run request
         in: body
         name: body
         required: true
         schema:
-          type: object
+          $ref: '#/definitions/user.RunAgentRequest'
       produces:
       - application/json
       responses:
         "200":
-          description: Agent response
+          description: Array of agent response events
           schema:
-            type: object
+            items:
+              type: object
+            type: array
         "400":
           description: Bad Request
           schema:
@@ -706,7 +757,7 @@ paths:
             $ref: '#/definitions/user.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Run agent
+      summary: Run agent (accepts both camelCase and snake_case)
       tags:
       - agent
   /agent/run_sse:
@@ -714,14 +765,17 @@ paths:
       consumes:
       - application/json
       description: Send a message to an agent and receive the response streamed as
-        Server-Sent Events.
+        Server-Sent Events. Both camelCase (canonical) and snake_case field names
+        are accepted at every nesting level — a normalization middleware converts
+        snake_case keys to camelCase recursively before the request reaches the ADK
+        handler.
       parameters:
-      - description: Run request with app_name, user_id, session_id, and new_message
+      - description: ADK run request
         in: body
         name: body
         required: true
         schema:
-          type: object
+          $ref: '#/definitions/user.RunAgentRequest'
       produces:
       - text/event-stream
       responses:
@@ -739,7 +793,7 @@ paths:
             $ref: '#/definitions/user.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Run agent (SSE streaming)
+      summary: Run agent SSE (accepts both camelCase and snake_case)
       tags:
       - agent
   /client/info:

--- a/server/main.go
+++ b/server/main.go
@@ -170,7 +170,7 @@ func main() {
 		middleware.ConversationRecorderSSE(filtered, executor, dataStore, "user"),
 		executor, dataStore, "user",
 	)
-	httpMux.Handle("/api/v1/agent/", userRecorded)
+	httpMux.Handle("/api/v1/agent/", middleware.SnakeCaseNormalize(userRecorded))
 	httpMux.Handle("/api/v1/voice/", newVoiceHandler(dataStore, agentRouter))
 
 	// A2A protocol endpoints (global discovery + per-agent card + JSON-RPC invoke)

--- a/server/middleware/normalize.go
+++ b/server/middleware/normalize.go
@@ -1,0 +1,150 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"unicode"
+)
+
+// SnakeCaseNormalize intercepts POST requests to /run and /run_sse and
+// recursively converts any snake_case JSON keys to camelCase before the
+// ADK handler processes the request. This allows API clients to send
+// either convention while ADK's strict decoder (DisallowUnknownFields)
+// receives the camelCase keys it expects.
+//
+// Keys that are already camelCase pass through unchanged. Single-word
+// keys (no underscore) are never modified. When both snake_case and
+// camelCase versions of the same key coexist in an object, the
+// camelCase value wins and the snake_case duplicate is dropped.
+func SnakeCaseNormalize(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !isRunPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil || len(body) == 0 {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		normalized, changed := normalizeJSON(body)
+		if !changed {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(normalized))
+		r.ContentLength = int64(len(normalized))
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isRunPath returns true if the URL path ends with /run or /run_sse.
+func isRunPath(path string) bool {
+	return strings.HasSuffix(path, "/run") || strings.HasSuffix(path, "/run_sse")
+}
+
+// normalizeJSON parses raw JSON bytes, recursively converts snake_case
+// keys to camelCase, and re-serializes. Returns the original bytes and
+// false if no conversion was needed or parsing fails.
+func normalizeJSON(data []byte) ([]byte, bool) {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return data, false
+	}
+	result, changed := normalizeValue(v)
+	if !changed {
+		return data, false
+	}
+	out, err := json.Marshal(result)
+	if err != nil {
+		return data, false
+	}
+	return out, true
+}
+
+// normalizeValue walks any JSON value recursively, converting snake_case
+// object keys to camelCase.
+func normalizeValue(v interface{}) (interface{}, bool) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		return normalizeObject(val)
+	case []interface{}:
+		return normalizeArray(val)
+	default:
+		return v, false
+	}
+}
+
+// normalizeObject converts snake_case keys in a JSON object to camelCase
+// and recurses into values. When both forms exist (e.g. "app_name" and
+// "appName"), the camelCase value takes precedence.
+func normalizeObject(obj map[string]interface{}) (map[string]interface{}, bool) {
+	result := make(map[string]interface{}, len(obj))
+	changed := false
+
+	for key, val := range obj {
+		camel := snakeToCamel(key)
+		newVal, valChanged := normalizeValue(val)
+		if valChanged {
+			changed = true
+		}
+		if camel != key {
+			changed = true
+			if _, hasCamel := obj[camel]; hasCamel {
+				continue
+			}
+			result[camel] = newVal
+		} else {
+			result[key] = newVal
+		}
+	}
+	return result, changed
+}
+
+// normalizeArray recurses into each element of a JSON array.
+func normalizeArray(arr []interface{}) ([]interface{}, bool) {
+	changed := false
+	result := make([]interface{}, len(arr))
+	for i, elem := range arr {
+		newElem, elemChanged := normalizeValue(elem)
+		if elemChanged {
+			changed = true
+		}
+		result[i] = newElem
+	}
+	return result, changed
+}
+
+// snakeToCamel converts a snake_case string to camelCase.
+// Single-word strings and strings without underscores are returned as-is.
+// Examples: "app_name" → "appName", "user_id" → "userId", "text" → "text".
+func snakeToCamel(s string) string {
+	if !strings.Contains(s, "_") {
+		return s
+	}
+	parts := strings.Split(s, "_")
+	var b strings.Builder
+	b.Grow(len(s))
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		if i == 0 {
+			b.WriteString(part)
+			continue
+		}
+		runes := []rune(part)
+		runes[0] = unicode.ToUpper(runes[0])
+		b.WriteString(string(runes))
+	}
+	return b.String()
+}

--- a/server/middleware/normalize_http_test.go
+++ b/server/middleware/normalize_http_test.go
@@ -1,0 +1,182 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSnakeCaseNormalize_RunEndpoint(t *testing.T) {
+	for _, path := range []string{"/api/v1/agent/run", "/api/v1/agent/run_sse"} {
+		t.Run(path, func(t *testing.T) {
+			input := `{"app_name":"agent1","user_id":"u1","session_id":"s1","new_message":{"role":"user","parts":[{"text":"hi"}]}}`
+
+			var downstream map[string]interface{}
+			handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &downstream)
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(input))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if _, ok := downstream["appName"]; !ok {
+				t.Error("expected appName in downstream body")
+			}
+			if _, ok := downstream["app_name"]; ok {
+				t.Error("unexpected app_name in downstream body")
+			}
+			if _, ok := downstream["userId"]; !ok {
+				t.Error("expected userId in downstream body")
+			}
+			if _, ok := downstream["sessionId"]; !ok {
+				t.Error("expected sessionId in downstream body")
+			}
+		})
+	}
+}
+
+func TestSnakeCaseNormalize_NestedConversion(t *testing.T) {
+	input := `{"app_name":"a","user_id":"u","session_id":"s","new_message":{"role":"user","parts":[{"inline_data":{"mime_type":"image/png","data":"abc"}}]}}`
+
+	var downstream []byte
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstream, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/run_sse", strings.NewReader(input))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	s := string(downstream)
+	if strings.Contains(s, "inline_data") {
+		t.Error("expected inline_data to be converted to inlineData")
+	}
+	if strings.Contains(s, "mime_type") {
+		t.Error("expected mime_type to be converted to mimeType")
+	}
+	if !strings.Contains(s, "inlineData") {
+		t.Error("expected inlineData in output")
+	}
+	if !strings.Contains(s, "mimeType") {
+		t.Error("expected mimeType in output")
+	}
+}
+
+func TestSnakeCaseNormalize_OtherPathsPassThrough(t *testing.T) {
+	input := `{"app_name":"agent1"}`
+	var downstream []byte
+
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstream, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/apps/a/users/u/sessions", strings.NewReader(input))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !strings.Contains(string(downstream), "app_name") {
+		t.Error("non-run paths should pass through unchanged")
+	}
+}
+
+func TestSnakeCaseNormalize_GETPassesThrough(t *testing.T) {
+	called := false
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/run", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("GET should pass through to next handler")
+	}
+}
+
+func TestSnakeCaseNormalize_AlreadyCamel(t *testing.T) {
+	input := `{"appName":"a","userId":"u","sessionId":"s","newMessage":{"role":"user","parts":[{"text":"hi"}]}}`
+
+	var downstream []byte
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstream, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/run", strings.NewReader(input))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if string(downstream) != input {
+		t.Errorf("already-camelCase body should pass through unchanged\ngot:  %s\nwant: %s", downstream, input)
+	}
+}
+
+func TestSnakeCaseNormalize_ContentLengthUpdated(t *testing.T) {
+	input := `{"app_name":"a","user_id":"u","session_id":"s"}`
+
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if r.ContentLength != int64(len(body)) {
+			t.Errorf("ContentLength = %d, body length = %d", r.ContentLength, len(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/run", strings.NewReader(input))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+}
+
+func TestSnakeCaseNormalize_EmptyBody(t *testing.T) {
+	called := false
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		body, _ := io.ReadAll(r.Body)
+		if len(body) != 0 {
+			t.Errorf("expected empty body, got %q", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/run", bytes.NewReader(nil))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("handler should be called even with empty body")
+	}
+}
+
+func TestSnakeCaseNormalize_InvalidJSON(t *testing.T) {
+	input := `not json at all`
+
+	var downstream []byte
+	handler := SnakeCaseNormalize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstream, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/run", strings.NewReader(input))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if string(downstream) != input {
+		t.Errorf("invalid JSON should pass through unchanged")
+	}
+}

--- a/server/middleware/normalize_test.go
+++ b/server/middleware/normalize_test.go
@@ -1,0 +1,169 @@
+package middleware
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSnakeToCamel(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"app_name", "appName"},
+		{"user_id", "userId"},
+		{"session_id", "sessionId"},
+		{"new_message", "newMessage"},
+		{"state_delta", "stateDelta"},
+		{"inline_data", "inlineData"},
+		{"function_call", "functionCall"},
+		{"function_response", "functionResponse"},
+		{"mime_type", "mimeType"},
+		{"display_name", "displayName"},
+		{"file_uri", "fileUri"},
+		{"code_execution_result", "codeExecutionResult"},
+		{"text", "text"},
+		{"role", "role"},
+		{"parts", "parts"},
+		{"data", "data"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := snakeToCamel(tc.in)
+		if got != tc.want {
+			t.Errorf("snakeToCamel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeJSON_TopLevel(t *testing.T) {
+	input := `{"app_name":"agent1","user_id":"u1","session_id":"s1","new_message":{"role":"user","parts":[{"text":"hi"}]}}`
+	out, changed := normalizeJSON([]byte(input))
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("invalid output JSON: %v", err)
+	}
+	for _, key := range []string{"appName", "userId", "sessionId", "newMessage"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing key %q in output", key)
+		}
+	}
+	for _, key := range []string{"app_name", "user_id", "session_id", "new_message"} {
+		if _, ok := m[key]; ok {
+			t.Errorf("snake_case key %q should not be present", key)
+		}
+	}
+}
+
+func TestNormalizeJSON_Nested(t *testing.T) {
+	input := `{"appName":"a","userId":"u","sessionId":"s","newMessage":{"role":"user","parts":[{"inline_data":{"mime_type":"image/png","data":"abc"}}]}}`
+	out, changed := normalizeJSON([]byte(input))
+	if !changed {
+		t.Fatal("expected changed=true for nested snake_case")
+	}
+	s := string(out)
+	assertContains(t, s, `"inlineData"`)
+	assertContains(t, s, `"mimeType"`)
+	assertNotContains(t, s, `"inline_data"`)
+	assertNotContains(t, s, `"mime_type"`)
+}
+
+func TestNormalizeJSON_AlreadyCamel(t *testing.T) {
+	input := `{"appName":"a","userId":"u","sessionId":"s","newMessage":{"role":"user","parts":[{"text":"hi"}]}}`
+	_, changed := normalizeJSON([]byte(input))
+	if changed {
+		t.Fatal("expected changed=false for already-camelCase body")
+	}
+}
+
+func TestNormalizeJSON_CamelTakesPrecedence(t *testing.T) {
+	input := `{"app_name":"snake","appName":"camel","user_id":"u1"}`
+	out, changed := normalizeJSON([]byte(input))
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("invalid output JSON: %v", err)
+	}
+	if v, _ := m["appName"].(string); v != "camel" {
+		t.Errorf("appName = %q, want %q", v, "camel")
+	}
+	if v, _ := m["userId"].(string); v != "u1" {
+		t.Errorf("userId = %q, want %q", v, "u1")
+	}
+}
+
+func TestNormalizeJSON_InvalidJSON(t *testing.T) {
+	input := `not json`
+	out, changed := normalizeJSON([]byte(input))
+	if changed {
+		t.Fatal("expected changed=false for invalid JSON")
+	}
+	if string(out) != input {
+		t.Errorf("expected original bytes returned")
+	}
+}
+
+func TestNormalizeJSON_EmptyObject(t *testing.T) {
+	_, changed := normalizeJSON([]byte(`{}`))
+	if changed {
+		t.Fatal("expected changed=false for empty object")
+	}
+}
+
+func TestNormalizeJSON_DeepNesting(t *testing.T) {
+	input := `{"new_message":{"role":"user","parts":[{"function_call":{"name":"test","partial_args":[{"will_continue":true}]}}]}}`
+	out, changed := normalizeJSON([]byte(input))
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	s := string(out)
+	assertContains(t, s, `"functionCall"`)
+	assertContains(t, s, `"partialArgs"`)
+	assertContains(t, s, `"willContinue"`)
+	assertNotContains(t, s, `"function_call"`)
+	assertNotContains(t, s, `"partial_args"`)
+	assertNotContains(t, s, `"will_continue"`)
+}
+
+func TestNormalizeJSON_StateDeltaKeysConverted(t *testing.T) {
+	input := `{"app_name":"a","state_delta":{"my_custom_key":"val"}}`
+	out, changed := normalizeJSON([]byte(input))
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	s := string(out)
+	assertContains(t, s, `"stateDelta"`)
+	assertContains(t, s, `"myCustomKey"`)
+}
+
+func TestNormalizeJSON_MixedSnakeAndCamelNested(t *testing.T) {
+	input := `{"appName":"a","new_message":{"role":"user","parts":[{"inline_data":{"mimeType":"image/png","data":"abc"}}]}}`
+	out, changed := normalizeJSON([]byte(input))
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	s := string(out)
+	assertContains(t, s, `"newMessage"`)
+	assertContains(t, s, `"inlineData"`)
+	assertNotContains(t, s, `"new_message"`)
+	assertNotContains(t, s, `"inline_data"`)
+}
+
+func assertContains(t *testing.T, s, substr string) {
+	t.Helper()
+	if !strings.Contains(s, substr) {
+		t.Errorf("expected output to contain %q, got:\n%s", substr, s)
+	}
+}
+
+func assertNotContains(t *testing.T, s, substr string) {
+	t.Helper()
+	if strings.Contains(s, substr) {
+		t.Errorf("expected output NOT to contain %q, got:\n%s", substr, s)
+	}
+}

--- a/website/content/docs/api.md
+++ b/website/content/docs/api.md
@@ -33,15 +33,19 @@ The request format for sending a message:
 
 ```json
 {
-  "app_name": "AGENT_OR_FLOW_ID",
-  "user_id": "user1",
-  "session_id": "session1",
-  "new_message": {
+  "appName": "AGENT_OR_FLOW_ID",
+  "userId": "user1",
+  "sessionId": "session1",
+  "newMessage": {
     "role": "user",
     "parts": [{ "text": "Hello!" }]
   }
 }
 ```
+
+{{< callout type="info" >}}
+Both **camelCase** (canonical) and **snake_case** field names are accepted. A normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler. This applies to all fields at every nesting level — including nested structures like `inlineData`, `mimeType`, `functionCall`, etc.
+{{< /callout >}}
 
 ### Other endpoints
 

--- a/website/public/docs/agents/index.html
+++ b/website/public/docs/agents/index.html
@@ -305,11 +305,11 @@
 <p>While the <strong>system prompt</strong> defines who the agent is, skills define <strong>what it knows</strong>. An agent with a &ldquo;Return Policy&rdquo; skill and a &ldquo;Product Catalog&rdquo; skill becomes a capable customer support representative without you having to cram everything into one massive prompt.</p>
 <p>Skills are especially powerful when shared across agents. Update a product catalog skill once, and every agent that uses it sees the change.</p>
 <p>For a deeper comparison of when to use skills vs. creating specialized agents, see <a href="/docs/skills-vs-agents/">Skills vs. Agents</a>.</p>
-<h2 id="context-guard-hahahugoshortcode66s4hbhb">
+<h2 id="context-guard-hahahugoshortcode9s4hbhb">
   Context Guard 
 <span class="docs-badge">Experimental</span>
 
-  <a class="heading-anchor" href="#context-guard-hahahugoshortcode66s4hbhb" aria-label="Link to this section">#</a>
+  <a class="heading-anchor" href="#context-guard-hahahugoshortcode9s4hbhb" aria-label="Link to this section">#</a>
 </h2>
 <p>Long conversations eventually hit the model&rsquo;s token limit and fail. Context Guard watches the conversation size and automatically summarizes older messages before that happens. Recent messages stay untouched.</p>
 <p>You set it up per-agent inside the <strong>LLM</strong> section. Two strategies:</p>

--- a/website/public/docs/api/index.html
+++ b/website/public/docs/api/index.html
@@ -183,15 +183,22 @@
 </ul>
 <p>The request format for sending a message:</p>
 <div class="highlight"><pre tabindex="0" class="chroma"><code class="language-json" data-lang="json"><span class="line"><span class="cl"><span class="p">{</span>
-</span></span><span class="line"><span class="cl">  <span class="nt">&#34;app_name&#34;</span><span class="p">:</span> <span class="s2">&#34;AGENT_OR_FLOW_ID&#34;</span><span class="p">,</span>
-</span></span><span class="line"><span class="cl">  <span class="nt">&#34;user_id&#34;</span><span class="p">:</span> <span class="s2">&#34;user1&#34;</span><span class="p">,</span>
-</span></span><span class="line"><span class="cl">  <span class="nt">&#34;session_id&#34;</span><span class="p">:</span> <span class="s2">&#34;session1&#34;</span><span class="p">,</span>
-</span></span><span class="line"><span class="cl">  <span class="nt">&#34;new_message&#34;</span><span class="p">:</span> <span class="p">{</span>
+</span></span><span class="line"><span class="cl">  <span class="nt">&#34;appName&#34;</span><span class="p">:</span> <span class="s2">&#34;AGENT_OR_FLOW_ID&#34;</span><span class="p">,</span>
+</span></span><span class="line"><span class="cl">  <span class="nt">&#34;userId&#34;</span><span class="p">:</span> <span class="s2">&#34;user1&#34;</span><span class="p">,</span>
+</span></span><span class="line"><span class="cl">  <span class="nt">&#34;sessionId&#34;</span><span class="p">:</span> <span class="s2">&#34;session1&#34;</span><span class="p">,</span>
+</span></span><span class="line"><span class="cl">  <span class="nt">&#34;newMessage&#34;</span><span class="p">:</span> <span class="p">{</span>
 </span></span><span class="line"><span class="cl">    <span class="nt">&#34;role&#34;</span><span class="p">:</span> <span class="s2">&#34;user&#34;</span><span class="p">,</span>
 </span></span><span class="line"><span class="cl">    <span class="nt">&#34;parts&#34;</span><span class="p">:</span> <span class="p">[{</span> <span class="nt">&#34;text&#34;</span><span class="p">:</span> <span class="s2">&#34;Hello!&#34;</span> <span class="p">}]</span>
 </span></span><span class="line"><span class="cl">  <span class="p">}</span>
 </span></span><span class="line"><span class="cl"><span class="p">}</span>
-</span></span></code></pre></div><h3 id="other-endpoints">
+</span></span></code></pre></div>
+
+
+<div class="docs-callout docs-callout--info">
+  Both <strong>camelCase</strong> (canonical) and <strong>snake_case</strong> field names are accepted. A normalization middleware converts snake_case keys to camelCase recursively before the request reaches the ADK handler. This applies to all fields at every nesting level — including nested structures like <code>inlineData</code>, <code>mimeType</code>, <code>functionCall</code>, etc.
+</div>
+
+<h3 id="other-endpoints">
   Other endpoints
   <a class="heading-anchor" href="#other-endpoints" aria-label="Link to this section">#</a>
 </h3>

--- a/website/public/docs/flows/index.html
+++ b/website/public/docs/flows/index.html
@@ -242,7 +242,8 @@
 <li>Magec replaces the placeholder with the actual output at runtime</li>
 </ol>
 <blockquote>
-<p><strong>Note:</strong> Magec uses <code>{{agent.output:variable}}</code> instead of <code>{variable}</code> for state references. This avoids conflicts with curly braces in your prompts, JSON examples, or any other content that uses <code>{</code> and <code>}</code>.</p></blockquote>
+<p><strong>Note:</strong> Magec uses <code>{{agent.output:variable}}</code> instead of <code>{variable}</code> for state references. This avoids conflicts with curly braces in your prompts, JSON examples, or any other content that uses <code>{</code> and <code>}</code>.</p>
+</blockquote>
 <p>This lets you build precise data pipelines. A &ldquo;researcher&rdquo; outputs structured findings, a &ldquo;writer&rdquo; references those findings in its prompt, a &ldquo;reviewer&rdquo; references both. Each agent sees exactly the context it needs.</p>
 <p>In parallel steps, all branches receive the same input. Their outputs are concatenated and passed to whatever comes next.</p>
 <h2 id="response-agents">


### PR DESCRIPTION
Middleware that intercepts POST /run and /run_sse, recursively converts all snake_case JSON keys to camelCase at every nesting level, and passes the normalized body to ADK.