### PR TITLE
chore: add SPDX Apache-2.0 license headers to source files

### DIFF
--- a/frontend/admin-ui/src/App.vue
+++ b/frontend/admin-ui/src/App.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <LoginScreen v-if="showLogin" @authenticated="onAuthenticated" />
 

--- a/frontend/admin-ui/src/components/AppDialog.vue
+++ b/frontend/admin-ui/src/components/AppDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <dialog
     ref="dialogRef"

--- a/frontend/admin-ui/src/components/Badge.vue
+++ b/frontend/admin-ui/src/components/Badge.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <span
     class="px-1.5 py-0.5 text-[10px] rounded font-medium"

--- a/frontend/admin-ui/src/components/Card.vue
+++ b/frontend/admin-ui/src/components/Card.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div
     class="bg-piedra-900 border border-piedra-700/50 rounded-xl p-4 transition-all duration-200"

--- a/frontend/admin-ui/src/components/ConfirmDialog.vue
+++ b/frontend/admin-ui/src/components/ConfirmDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <dialog
     ref="dialogRef"

--- a/frontend/admin-ui/src/components/DetailRow.vue
+++ b/frontend/admin-ui/src/components/DetailRow.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="detail-row flex justify-between items-baseline gap-4">
     <span class="text-[11px] text-arena-500 flex-shrink-0">{{ label }}</span>

--- a/frontend/admin-ui/src/components/EmptyState.vue
+++ b/frontend/admin-ui/src/components/EmptyState.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="text-center py-16 text-arena-500">
     <div v-if="icon" class="mx-auto mb-4 w-14 h-14 rounded-2xl flex items-center justify-center" :class="iconBg">

--- a/frontend/admin-ui/src/components/FormInput.vue
+++ b/frontend/admin-ui/src/components/FormInput.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <input
     :type="type"

--- a/frontend/admin-ui/src/components/FormLabel.vue
+++ b/frontend/admin-ui/src/components/FormLabel.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <label class="block text-xs text-arena-400 mb-1">
     {{ label }}

--- a/frontend/admin-ui/src/components/FormSelect.vue
+++ b/frontend/admin-ui/src/components/FormSelect.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div ref="wrapperRef" class="relative">
     <button

--- a/frontend/admin-ui/src/components/FormToggle.vue
+++ b/frontend/admin-ui/src/components/FormToggle.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <button
     type="button"

--- a/frontend/admin-ui/src/components/Icon.vue
+++ b/frontend/admin-ui/src/components/Icon.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <svg class="flex-shrink-0" :class="sizeClass" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path stroke-linecap="round" stroke-linejoin="round" :stroke-width="strokeWidth" :d="paths[name]" />

--- a/frontend/admin-ui/src/components/LoginScreen.vue
+++ b/frontend/admin-ui/src/components/LoginScreen.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="min-h-screen flex items-center justify-center bg-piedra-950">
     <div class="w-full max-w-sm mx-auto px-6">

--- a/frontend/admin-ui/src/components/OverviewBadges.vue
+++ b/frontend/admin-ui/src/components/OverviewBadges.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex items-center gap-2 text-[11px]">
     <span class="px-2 py-0.5 bg-piedra-800 rounded-full text-arena-300">{{ store.backends.length }} backend{{ store.backends.length !== 1 ? 's' : '' }}</span>

--- a/frontend/admin-ui/src/components/SearchPalette.vue
+++ b/frontend/admin-ui/src/components/SearchPalette.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <Teleport to="body">
     <Transition name="search">

--- a/frontend/admin-ui/src/components/SegmentedControl.vue
+++ b/frontend/admin-ui/src/components/SegmentedControl.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="inline-flex items-center bg-piedra-800 rounded-lg border border-piedra-700/50 p-0.5">
     <button

--- a/frontend/admin-ui/src/components/Sidebar.vue
+++ b/frontend/admin-ui/src/components/Sidebar.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <aside
     class="flex flex-col h-full border-r border-piedra-700/50 bg-piedra-900 transition-all duration-200 flex-shrink-0"

--- a/frontend/admin-ui/src/components/SkeletonCard.vue
+++ b/frontend/admin-ui/src/components/SkeletonCard.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div :class="grid ? 'grid gap-3 grid-cols-1 sm:grid-cols-2' : 'space-y-3'">
     <div v-for="i in count" :key="i" class="bg-piedra-900 border border-piedra-700/50 rounded-xl p-4 animate-pulse">

--- a/frontend/admin-ui/src/components/Toast.vue
+++ b/frontend/admin-ui/src/components/Toast.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <Teleport to="body">
     <div class="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none">

--- a/frontend/admin-ui/src/components/Tooltip.vue
+++ b/frontend/admin-ui/src/components/Tooltip.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="relative inline-flex group/tooltip">
     <slot />

--- a/frontend/admin-ui/src/components/TopBar.vue
+++ b/frontend/admin-ui/src/components/TopBar.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <header class="flex items-center justify-between px-5 py-4 border-b border-piedra-700/50 bg-piedra-900/60 flex-shrink-0">
     <!-- Left: menu + section title -->

--- a/frontend/admin-ui/src/lib/api/agents.js
+++ b/frontend/admin-ui/src/lib/api/agents.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const agentsApi = {

--- a/frontend/admin-ui/src/lib/api/backends.js
+++ b/frontend/admin-ui/src/lib/api/backends.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const backendsApi = {

--- a/frontend/admin-ui/src/lib/api/backup.js
+++ b/frontend/admin-ui/src/lib/api/backup.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { getAuthHeaders } from '../auth.js'
 
 const BASE = '/api/v1/admin'

--- a/frontend/admin-ui/src/lib/api/client.js
+++ b/frontend/admin-ui/src/lib/api/client.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { getAuthHeaders } from '../auth.js'
 
 const BASE = '/api/v1/admin'

--- a/frontend/admin-ui/src/lib/api/clients.js
+++ b/frontend/admin-ui/src/lib/api/clients.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const clientsApi = {

--- a/frontend/admin-ui/src/lib/api/commands.js
+++ b/frontend/admin-ui/src/lib/api/commands.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const commandsApi = {

--- a/frontend/admin-ui/src/lib/api/conversations.js
+++ b/frontend/admin-ui/src/lib/api/conversations.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const conversationsApi = {

--- a/frontend/admin-ui/src/lib/api/flows.js
+++ b/frontend/admin-ui/src/lib/api/flows.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const flowsApi = {

--- a/frontend/admin-ui/src/lib/api/index.js
+++ b/frontend/admin-ui/src/lib/api/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export { backendsApi } from './backends.js'
 export { agentsApi } from './agents.js'
 export { memoryApi } from './memory.js'

--- a/frontend/admin-ui/src/lib/api/mcps.js
+++ b/frontend/admin-ui/src/lib/api/mcps.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const mcpsApi = {

--- a/frontend/admin-ui/src/lib/api/memory.js
+++ b/frontend/admin-ui/src/lib/api/memory.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const memoryApi = {

--- a/frontend/admin-ui/src/lib/api/secrets.js
+++ b/frontend/admin-ui/src/lib/api/secrets.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const secretsApi = {

--- a/frontend/admin-ui/src/lib/api/settings.js
+++ b/frontend/admin-ui/src/lib/api/settings.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const settingsApi = {

--- a/frontend/admin-ui/src/lib/api/skills.js
+++ b/frontend/admin-ui/src/lib/api/skills.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 import { getAuthHeaders } from '../auth.js'
 

--- a/frontend/admin-ui/src/lib/api/voice.js
+++ b/frontend/admin-ui/src/lib/api/voice.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { request } from './client.js'
 
 export const voiceApi = {

--- a/frontend/admin-ui/src/lib/auth.js
+++ b/frontend/admin-ui/src/lib/auth.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { ref } from 'vue'
 
 const adminPassword = ref('')

--- a/frontend/admin-ui/src/lib/frontmatter.js
+++ b/frontend/admin-ui/src/lib/frontmatter.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import yaml from 'js-yaml'
 
 const FENCE = '---'

--- a/frontend/admin-ui/src/lib/markdown.js
+++ b/frontend/admin-ui/src/lib/markdown.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 // Magec-flavoured markdown renderer.
 //
 // We don't use Tailwind's `prose` utility (the typography plugin isn't

--- a/frontend/admin-ui/src/lib/metadata.js
+++ b/frontend/admin-ui/src/lib/metadata.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 const METADATA_REGEX = /<!--MAGEC_META:.*?:MAGEC_META-->\n?/gs
 const THREAD_HISTORY_REGEX = /<!--MAGEC_THREAD_HISTORY:.*?:MAGEC_THREAD_HISTORY-->\n?/gs
 

--- a/frontend/admin-ui/src/lib/stores/data.js
+++ b/frontend/admin-ui/src/lib/stores/data.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import {

--- a/frontend/admin-ui/src/main.js
+++ b/frontend/admin-ui/src/main.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'

--- a/frontend/admin-ui/src/style.css
+++ b/frontend/admin-ui/src/style.css
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 @import "tailwindcss";
 
 @theme {

--- a/frontend/admin-ui/src/views/agents/AgentDetail.vue
+++ b/frontend/admin-ui/src/views/agents/AgentDetail.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="border-t border-piedra-700/30 p-4 mt-3 space-y-3">
     <p v-if="agent.description" class="text-xs text-arena-400 leading-relaxed">{{ agent.description }}</p>

--- a/frontend/admin-ui/src/views/agents/AgentDialog.vue
+++ b/frontend/admin-ui/src/views/agents/AgentDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Agent' : 'New Agent'" size="lg" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/agents/AgentsList.vue
+++ b/frontend/admin-ui/src/views/agents/AgentsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/backends/BackendDialog.vue
+++ b/frontend/admin-ui/src/views/backends/BackendDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Backend' : 'New Backend'" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/backends/BackendsList.vue
+++ b/frontend/admin-ui/src/views/backends/BackendsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/clients/ClientDialog.vue
+++ b/frontend/admin-ui/src/views/clients/ClientDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Client' : 'New Client'" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/clients/ClientsList.vue
+++ b/frontend/admin-ui/src/views/clients/ClientsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/commands/CommandDialog.vue
+++ b/frontend/admin-ui/src/views/commands/CommandDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Command' : 'New Command'" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/commands/CommandsList.vue
+++ b/frontend/admin-ui/src/views/commands/CommandsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/conversations/ConversationDetail.vue
+++ b/frontend/admin-ui/src/views/conversations/ConversationDetail.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <!-- Header -->

--- a/frontend/admin-ui/src/views/conversations/ConversationsList.vue
+++ b/frontend/admin-ui/src/views/conversations/ConversationsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <!-- Header -->

--- a/frontend/admin-ui/src/views/conversations/ConversationsView.vue
+++ b/frontend/admin-ui/src/views/conversations/ConversationsView.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <Transition name="section" mode="out-in">
     <ConversationDetail

--- a/frontend/admin-ui/src/views/flows/FlowBlock.vue
+++ b/frontend/admin-ui/src/views/flows/FlowBlock.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <!-- AGENT NODE -->
   <div v-if="step.type === 'agent'" class="flow-agent group relative">

--- a/frontend/admin-ui/src/views/flows/FlowCanvas.vue
+++ b/frontend/admin-ui/src/views/flows/FlowCanvas.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flow-canvas" ref="canvasRef" @wheel.prevent="onWheel" @pointerdown="onCanvasPointerDown">
     <!-- Empty state: pick root type -->

--- a/frontend/admin-ui/src/views/flows/FlowDialog.vue
+++ b/frontend/admin-ui/src/views/flows/FlowDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Flow' : 'New Flow'" size="2xl" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/flows/FlowsList.vue
+++ b/frontend/admin-ui/src/views/flows/FlowsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/flows/LoopConfigDialog.vue
+++ b/frontend/admin-ui/src/views/flows/LoopConfigDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" title="Loop step settings" size="md" @save="save" @close="reset">
     <div class="space-y-5">

--- a/frontend/admin-ui/src/views/mcps/McpDialog.vue
+++ b/frontend/admin-ui/src/views/mcps/McpDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit MCP Server' : 'New MCP Server'" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/mcps/McpsList.vue
+++ b/frontend/admin-ui/src/views/mcps/McpsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/memory/MemoryCard.vue
+++ b/frontend/admin-ui/src/views/memory/MemoryCard.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <Card color="green">
     <div class="flex items-start gap-3">

--- a/frontend/admin-ui/src/views/memory/MemoryDialog.vue
+++ b/frontend/admin-ui/src/views/memory/MemoryDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="dialogTitle" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/memory/MemoryList.vue
+++ b/frontend/admin-ui/src/views/memory/MemoryList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/secrets/SecretDialog.vue
+++ b/frontend/admin-ui/src/views/secrets/SecretDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Secret' : 'New Secret'" @save="save">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/secrets/SecretsList.vue
+++ b/frontend/admin-ui/src/views/secrets/SecretsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/src/views/settings/BackupSection.vue
+++ b/frontend/admin-ui/src/views/settings/BackupSection.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="max-w-2xl space-y-6">
     <!-- Header -->

--- a/frontend/admin-ui/src/views/settings/RuntimeSection.vue
+++ b/frontend/admin-ui/src/views/settings/RuntimeSection.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="max-w-2xl space-y-6">
     <!-- Header -->

--- a/frontend/admin-ui/src/views/settings/SettingsView.vue
+++ b/frontend/admin-ui/src/views/settings/SettingsView.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="max-w-3xl mx-auto px-4 sm:px-6 py-5 space-y-8">
     <!-- Search -->

--- a/frontend/admin-ui/src/views/skills/EmptyTab.vue
+++ b/frontend/admin-ui/src/views/skills/EmptyTab.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <!-- EmptyTab — quiet empty-state slug for the skill viewer tabs.
        Centered, generous vertical padding, muted glyph + single line

--- a/frontend/admin-ui/src/views/skills/SkillDialog.vue
+++ b/frontend/admin-ui/src/views/skills/SkillDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" title="Upload Skill" size="lg">
     <div class="space-y-4">

--- a/frontend/admin-ui/src/views/skills/SkillViewDialog.vue
+++ b/frontend/admin-ui/src/views/skills/SkillViewDialog.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <AppDialog ref="dialogRef" :title="title" size="xl">
     <div v-if="loading" class="text-center text-xs text-arena-500 py-12">Loading…</div>

--- a/frontend/admin-ui/src/views/skills/SkillsList.vue
+++ b/frontend/admin-ui/src/views/skills/SkillsList.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">

--- a/frontend/admin-ui/vite.config.js
+++ b/frontend/admin-ui/vite.config.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'

--- a/frontend/voice-ui/public/audio-processor.worklet.js
+++ b/frontend/voice-ui/public/audio-processor.worklet.js
@@ -1,18 +1,5 @@
-/*
- * Copyright 2025 Alby Hernández
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 /**
  * AudioWorklet processor for capturing raw audio samples

--- a/frontend/voice-ui/src/App.vue
+++ b/frontend/voice-ui/src/App.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <PairingScreen v-if="store.showPairing" />
   <div v-else class="h-full flex">

--- a/frontend/voice-ui/src/components/AgentSwitcher.vue
+++ b/frontend/voice-ui/src/components/AgentSwitcher.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div ref="root" class="relative">
     <button

--- a/frontend/voice-ui/src/components/AppHeader.vue
+++ b/frontend/voice-ui/src/components/AppHeader.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <header class="border-b border-piedra-700/50 backdrop-blur-sm bg-piedra-950/90 flex-shrink-0">
     <div class="px-3 sm:px-4 py-3 sm:py-4 flex items-center justify-between gap-2">

--- a/frontend/voice-ui/src/components/AppSidebar.vue
+++ b/frontend/voice-ui/src/components/AppSidebar.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <aside
     id="sidebar"

--- a/frontend/voice-ui/src/components/CentellaOrb.vue
+++ b/frontend/voice-ui/src/components/CentellaOrb.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <canvas
     ref="canvasRef"

--- a/frontend/voice-ui/src/components/ChatMessage.vue
+++ b/frontend/voice-ui/src/components/ChatMessage.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex gap-3 items-start">
     <div

--- a/frontend/voice-ui/src/components/FooterClock.vue
+++ b/frontend/voice-ui/src/components/FooterClock.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <footer class="border-t border-piedra-700/50 py-3 flex-shrink-0">
     <p class="text-center text-xs text-arena-500">{{ clockText }}</p>

--- a/frontend/voice-ui/src/components/NotificationItem.vue
+++ b/frontend/voice-ui/src/components/NotificationItem.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="group flex items-start gap-3 p-3 rounded-xl transition-all hover:bg-opacity-30" :class="config.bg">
     <div class="flex-shrink-0 mt-0.5" v-html="config.icon" />

--- a/frontend/voice-ui/src/components/PairingScreen.vue
+++ b/frontend/voice-ui/src/components/PairingScreen.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="fixed inset-0 z-50 bg-piedra-950 flex items-center justify-center">
     <div class="w-full max-w-sm px-6">

--- a/frontend/voice-ui/src/components/PanelAssistant.vue
+++ b/frontend/voice-ui/src/components/PanelAssistant.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex-1 flex flex-col p-4 gap-4 overflow-hidden">
     <div class="flex-1 flex items-center justify-center overflow-hidden min-h-[180px]">

--- a/frontend/voice-ui/src/components/PanelHistory.vue
+++ b/frontend/voice-ui/src/components/PanelHistory.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
     <div class="flex items-center justify-between p-3 border-b border-piedra-700/50 flex-shrink-0">

--- a/frontend/voice-ui/src/components/PanelNotifications.vue
+++ b/frontend/voice-ui/src/components/PanelNotifications.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
     <div class="flex items-center justify-between p-3 border-b border-piedra-700/50 flex-shrink-0">

--- a/frontend/voice-ui/src/components/PanelSettings.vue
+++ b/frontend/voice-ui/src/components/PanelSettings.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
     <div class="flex items-center gap-2 p-3 border-b border-piedra-700/50 flex-shrink-0">

--- a/frontend/voice-ui/src/components/SessionItem.vue
+++ b/frontend/voice-ui/src/components/SessionItem.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="group relative">
     <button

--- a/frontend/voice-ui/src/components/StatusIndicator.vue
+++ b/frontend/voice-ui/src/components/StatusIndicator.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <template>
   <div class="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1 sm:py-1.5 bg-piedra-800/50 rounded-lg mr-1 sm:mr-2">
     <div class="relative flex items-center justify-center w-3 h-3 sm:w-4 sm:h-4">

--- a/frontend/voice-ui/src/lib/api/AgentClient.js
+++ b/frontend/voice-ui/src/lib/api/AgentClient.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { CONFIG } from '../config.js'
 
 export class AgentClient {

--- a/frontend/voice-ui/src/lib/api/ClientAuth.js
+++ b/frontend/voice-ui/src/lib/api/ClientAuth.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 const STORAGE_KEY = 'magec_client_token'
 
 class ClientAuth {

--- a/frontend/voice-ui/src/lib/api/index.js
+++ b/frontend/voice-ui/src/lib/api/index.js
@@ -1,2 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export { AgentClient } from './AgentClient.js'
 export { clientAuth } from './ClientAuth.js'

--- a/frontend/voice-ui/src/lib/audio/AudioCapture.js
+++ b/frontend/voice-ui/src/lib/audio/AudioCapture.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class AudioCapture {
   constructor() {
     this.audioContext = null

--- a/frontend/voice-ui/src/lib/audio/AudioConverter.js
+++ b/frontend/voice-ui/src/lib/audio/AudioConverter.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class AudioConverter {
   static async blobToWav(blob, targetSampleRate = 16000) {
     const arrayBuffer = await blob.arrayBuffer()

--- a/frontend/voice-ui/src/lib/audio/AudioRecorder.js
+++ b/frontend/voice-ui/src/lib/audio/AudioRecorder.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class AudioRecorder {
   constructor(micStream) {
     this.micStream = micStream

--- a/frontend/voice-ui/src/lib/audio/FeedbackSound.js
+++ b/frontend/voice-ui/src/lib/audio/FeedbackSound.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class FeedbackSound {
   constructor(options = {}) {
     this.audioContext = null

--- a/frontend/voice-ui/src/lib/audio/OpenAITTS.js
+++ b/frontend/voice-ui/src/lib/audio/OpenAITTS.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class OpenAITTS {
   constructor() {
     this._audio = null

--- a/frontend/voice-ui/src/lib/audio/VoiceEventsClient.js
+++ b/frontend/voice-ui/src/lib/audio/VoiceEventsClient.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class VoiceEventsClient {
   constructor(config = {}) {
     this.config = {

--- a/frontend/voice-ui/src/lib/audio/index.js
+++ b/frontend/voice-ui/src/lib/audio/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export { AudioCapture } from './AudioCapture.js'
 export { AudioRecorder } from './AudioRecorder.js'
 export { AudioConverter } from './AudioConverter.js'

--- a/frontend/voice-ui/src/lib/config.js
+++ b/frontend/voice-ui/src/lib/config.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export const CONFIG = {
   transcription: {
     model: 'parakeet'

--- a/frontend/voice-ui/src/lib/i18n/en.js
+++ b/frontend/voice-ui/src/lib/i18n/en.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export default {
   app: {
     title: 'Magec',

--- a/frontend/voice-ui/src/lib/i18n/es.js
+++ b/frontend/voice-ui/src/lib/i18n/es.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export default {
   app: {
     title: 'Magec',

--- a/frontend/voice-ui/src/lib/i18n/index.js
+++ b/frontend/voice-ui/src/lib/i18n/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { ref, computed } from 'vue'
 import es from './es.js'
 import en from './en.js'

--- a/frontend/voice-ui/src/lib/session/SessionManager.js
+++ b/frontend/voice-ui/src/lib/session/SessionManager.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { CONFIG } from '../config.js'
 
 export class SessionManager {

--- a/frontend/voice-ui/src/lib/session/SessionService.js
+++ b/frontend/voice-ui/src/lib/session/SessionService.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { CONFIG } from '../config.js'
 import { stripMetadata } from '../utils/metadata.js'
 

--- a/frontend/voice-ui/src/lib/session/index.js
+++ b/frontend/voice-ui/src/lib/session/index.js
@@ -1,2 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export { SessionManager } from './SessionManager.js'
 export { SessionService } from './SessionService.js'

--- a/frontend/voice-ui/src/lib/settings/SettingsManager.js
+++ b/frontend/voice-ui/src/lib/settings/SettingsManager.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 const STORAGE_PREFIX = 'magec_settings'
 
 const DEFAULT_SETTINGS = {

--- a/frontend/voice-ui/src/lib/stores/app.js
+++ b/frontend/voice-ui/src/lib/stores/app.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { CONFIG } from '../config.js'

--- a/frontend/voice-ui/src/lib/transcription/RemoteTranscriber.js
+++ b/frontend/voice-ui/src/lib/transcription/RemoteTranscriber.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { AudioConverter } from '../audio/AudioConverter.js'
 
 export class RemoteTranscriber {

--- a/frontend/voice-ui/src/lib/utils/WakeLock.js
+++ b/frontend/voice-ui/src/lib/utils/WakeLock.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class WakeLock {
   constructor() {
     this._wakeLock = null

--- a/frontend/voice-ui/src/lib/utils/format.js
+++ b/frontend/voice-ui/src/lib/utils/format.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export function escapeHtml(text) {
   const div = document.createElement('div')
   div.textContent = text

--- a/frontend/voice-ui/src/lib/utils/metadata.js
+++ b/frontend/voice-ui/src/lib/utils/metadata.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 const METADATA_REGEX = /<!--MAGEC_META:.*?:MAGEC_META-->\n?/gs
 
 export function stripMetadata(text) {

--- a/frontend/voice-ui/src/main.js
+++ b/frontend/voice-ui/src/main.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'

--- a/frontend/voice-ui/src/style.css
+++ b/frontend/voice-ui/src/style.css
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 @import "tailwindcss";
 
 @theme {

--- a/frontend/voice-ui/vite.config.js
+++ b/frontend/voice-ui/vite.config.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'

--- a/scripts/download-model.go
+++ b/scripts/download-model.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 // Download auxiliary models (VAD, embedding, etc) from HuggingFace Hey-Buddy.
 package main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+# SPDX-License-Identifier: Apache-2.0
+
 # Magec interactive installer — https://github.com/achetronic/magec
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/achetronic/magec/master/scripts/install.sh | bash

--- a/server/a2a/handler.go
+++ b/server/a2a/handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package a2a
 
 import (

--- a/server/agent/agent.go
+++ b/server/agent/agent.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package agent
 

--- a/server/agent/base_toolset.go
+++ b/server/agent/base_toolset.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package agent
 
 import (

--- a/server/agent/flow.go
+++ b/server/agent/flow.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package agent
 

--- a/server/agent/flowexit/compiler.go
+++ b/server/agent/flowexit/compiler.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 // Package flowexit owns the loop-exit-by-expression mechanism. It compiles
 // the operator-supplied CEL expression once (at flow build time, after the

--- a/server/agent/flowexit/compiler_test.go
+++ b/server/agent/flowexit/compiler_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package flowexit
 

--- a/server/agent/flowexit/evaluator.go
+++ b/server/agent/flowexit/evaluator.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package flowexit
 

--- a/server/agent/flowexit/evaluator_test.go
+++ b/server/agent/flowexit/evaluator_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package flowexit
 

--- a/server/agent/tools/artifacts/toolset.go
+++ b/server/agent/tools/artifacts/toolset.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package artifacts
 
 import (

--- a/server/agent/tools/flowstate/toolset.go
+++ b/server/agent/tools/flowstate/toolset.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 // Package flowstate exposes the set_state and get_state tools, which let
 // agents that run inside a flow share a key/value scratchpad backed by the

--- a/server/agent/tools/flowstate/toolset_test.go
+++ b/server/agent/tools/flowstate/toolset_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package flowstate
 

--- a/server/agent/tools/skills/agentfs.go
+++ b/server/agent/tools/skills/agentfs.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 // Package skills wires Magec's on-disk skill packages
 // (data/skills/{slug}/SKILL.md plus optional references/, assets/, scripts/

--- a/server/agent/tools/skills/agentfs_test.go
+++ b/server/agent/tools/skills/agentfs_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package skills
 

--- a/server/agent/tools/skills/package.go
+++ b/server/agent/tools/skills/package.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package skills
 

--- a/server/agent/tools/skills/package_test.go
+++ b/server/agent/tools/skills/package_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package skills
 

--- a/server/agent/tools/skills/tolerant.go
+++ b/server/agent/tools/skills/tolerant.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package skills
 

--- a/server/agent/tools/skills/tolerant_test.go
+++ b/server/agent/tools/skills/tolerant_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package skills
 

--- a/server/api/admin/agents.go
+++ b/server/api/admin/agents.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/backends.go
+++ b/server/api/admin/backends.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/backup.go
+++ b/server/api/admin/backup.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/clients.go
+++ b/server/api/admin/clients.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/commands.go
+++ b/server/api/admin/commands.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/conversations.go
+++ b/server/api/admin/conversations.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/doc.go
+++ b/server/api/admin/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 // Package admin provides the Magec Admin REST API.
 //
 // @title           Magec Admin API

--- a/server/api/admin/flows.go
+++ b/server/api/admin/flows.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/flows_test.go
+++ b/server/api/admin/flows_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package admin
 

--- a/server/api/admin/handler.go
+++ b/server/api/admin/handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/mcps.go
+++ b/server/api/admin/mcps.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/memory.go
+++ b/server/api/admin/memory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/secrets.go
+++ b/server/api/admin/secrets.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/settings.go
+++ b/server/api/admin/settings.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/admin/skills.go
+++ b/server/api/admin/skills.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package admin
 

--- a/server/api/admin/voice.go
+++ b/server/api/admin/voice.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package admin
 
 import (

--- a/server/api/user/a2a_swagger.go
+++ b/server/api/user/a2a_swagger.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package user
 
 // A2A endpoint documentation stubs.

--- a/server/api/user/adk_swagger.go
+++ b/server/api/user/adk_swagger.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package user
 
 // ADK endpoint documentation stubs.

--- a/server/api/user/doc.go
+++ b/server/api/user/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 // Package user provides the Magec User-facing REST API.
 //
 // @title           Magec User API

--- a/server/api/user/handlers.go
+++ b/server/api/user/handlers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package user
 
 import (

--- a/server/clients/cron/cron.go
+++ b/server/clients/cron/cron.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cron
 
 import (

--- a/server/clients/cron/scheduler.go
+++ b/server/clients/cron/scheduler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cron
 
 import (

--- a/server/clients/cron/spec.go
+++ b/server/clients/cron/spec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cron
 
 import (

--- a/server/clients/direct/spec.go
+++ b/server/clients/direct/spec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package direct
 
 import (

--- a/server/clients/discord/bot.go
+++ b/server/clients/discord/bot.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package discord
 
 import (

--- a/server/clients/discord/spec.go
+++ b/server/clients/discord/spec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package discord
 
 import (

--- a/server/clients/executor.go
+++ b/server/clients/executor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package clients
 
 import (

--- a/server/clients/msgutil/attachments.go
+++ b/server/clients/msgutil/attachments.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 // Package msgutil exposes shared helpers used by every chat client.
 //

--- a/server/clients/msgutil/attachments_test.go
+++ b/server/clients/msgutil/attachments_test.go
@@ -1,7 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package msgutil
 

--- a/server/clients/msgutil/msgutil.go
+++ b/server/clients/msgutil/msgutil.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package msgutil
 
 import (

--- a/server/clients/msgutil/msgutil_test.go
+++ b/server/clients/msgutil/msgutil_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package msgutil
 
 import (

--- a/server/clients/msgutil/sse.go
+++ b/server/clients/msgutil/sse.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package msgutil
 
 import (

--- a/server/clients/provider.go
+++ b/server/clients/provider.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package clients
 
 // Schema is a JSON Schema object represented as a plain map so providers can

--- a/server/clients/registry.go
+++ b/server/clients/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package clients
 
 import (

--- a/server/clients/slack/bot.go
+++ b/server/clients/slack/bot.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package slack
 
 import (

--- a/server/clients/slack/spec.go
+++ b/server/clients/slack/spec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package slack
 
 import (

--- a/server/clients/telegram/bot.go
+++ b/server/clients/telegram/bot.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package telegram
 

--- a/server/clients/telegram/spec.go
+++ b/server/clients/telegram/spec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package telegram
 
 import (

--- a/server/clients/webhook/handler.go
+++ b/server/clients/webhook/handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package webhook
 
 import (

--- a/server/clients/webhook/spec.go
+++ b/server/clients/webhook/spec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package webhook
 
 import (

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package config
 

--- a/server/ephemeral/ephemeral.go
+++ b/server/ephemeral/ephemeral.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ephemeral provides primitives for issuing self-contained, signed,
 // time-limited tokens that grant one-shot access to a specific resource.
 //

--- a/server/ephemeral/ephemeral_test.go
+++ b/server/ephemeral/ephemeral_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package ephemeral
 
 import (

--- a/server/frontend/embed.go
+++ b/server/frontend/embed.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package frontend
 
 import (

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 // Package logging provides a simple configurable logger using slog.
 package logging

--- a/server/main.go
+++ b/server/main.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Alby Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/server/memory/postgres/postgres.go
+++ b/server/memory/postgres/postgres.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package postgres
 
 import (

--- a/server/memory/provider.go
+++ b/server/memory/provider.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package memory
 
 import (

--- a/server/memory/redis/redis.go
+++ b/server/memory/redis/redis.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package redis
 
 import (

--- a/server/memory/registry.go
+++ b/server/memory/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package memory
 
 import (

--- a/server/middleware/flowfilter.go
+++ b/server/middleware/flowfilter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/normalize.go
+++ b/server/middleware/normalize.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/normalize_http_test.go
+++ b/server/middleware/normalize_http_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/normalize_test.go
+++ b/server/middleware/normalize_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/recorder.go
+++ b/server/middleware/recorder.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/sessionensure.go
+++ b/server/middleware/sessionensure.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/sessionstate.go
+++ b/server/middleware/sessionstate.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/middleware/sseidle.go
+++ b/server/middleware/sseidle.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package middleware
 
 import (

--- a/server/models/embed.go
+++ b/server/models/embed.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package models
 
 import (

--- a/server/schema/validate.go
+++ b/server/schema/validate.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import (

--- a/server/store/conversations.go
+++ b/server/store/conversations.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package store
 
 import (

--- a/server/store/conversations_test.go
+++ b/server/store/conversations_test.go
@@ -1,7 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package store
 

--- a/server/store/crypto.go
+++ b/server/store/crypto.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package store
 
 import (

--- a/server/store/flow_test.go
+++ b/server/store/flow_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package store
 

--- a/server/store/skills_broken_test.go
+++ b/server/store/skills_broken_test.go
@@ -1,10 +1,5 @@
-// Copyright 2025 Alberto Hernández
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package store
 

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package store
 
 import (

--- a/server/store/types.go
+++ b/server/store/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package store
 
 import (

--- a/server/tools.go
+++ b/server/tools.go
@@ -1,5 +1,8 @@
 //go:build tools
 
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package tools
 
 import (

--- a/server/voice/detector.go
+++ b/server/voice/detector.go
@@ -1,18 +1,5 @@
-/*
- * Copyright 2025 Alby Hernández
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package voice
 

--- a/server/voice/gemini/gemini.go
+++ b/server/voice/gemini/gemini.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package gemini
 
 import (

--- a/server/voice/handler.go
+++ b/server/voice/handler.go
@@ -1,18 +1,5 @@
-/*
- * Copyright 2025 Alby Hernández
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package voice
 

--- a/server/voice/openai/openai.go
+++ b/server/voice/openai/openai.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package openai
 
 import (

--- a/server/voice/provider.go
+++ b/server/voice/provider.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package voice
 
 import (

--- a/server/voice/registry.go
+++ b/server/voice/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package voice
 
 import (

--- a/server/voice/registry_test.go
+++ b/server/voice/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package voice
 
 import (

--- a/server/voice/resampler.go
+++ b/server/voice/resampler.go
@@ -1,18 +1,5 @@
-/*
- * Copyright 2025 Alby Hernández
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package voice
 

--- a/server/voice/vad.go
+++ b/server/voice/vad.go
@@ -1,18 +1,5 @@
-/*
- * Copyright 2025 Alby Hernández
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package voice
 

--- a/website/themes/magec/static/css/style.css
+++ b/website/themes/magec/static/css/style.css
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com> */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 :root {
   --piedra-950: #121214;
   --piedra-900: #1a1a1d;

--- a/website/themes/magec/static/js/centella.js
+++ b/website/themes/magec/static/js/centella.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 export class Centella {
   constructor(canvas) {
     this.canvas = canvas;

--- a/website/themes/magec/static/js/main.js
+++ b/website/themes/magec/static/js/main.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 import { Centella } from './centella.js';
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Add the standard two-line SPDX header to every first-party source file (Go, JS,
Vue, CSS, shell) so the Apache-2.0 license is machine-readable per file:

```
SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
SPDX-License-Identifier: Apache-2.0
```

Any pre-existing Apache/copyright boilerplate header was replaced by these two
lines. Comment syntax is chosen per language (`//`, `/* */`, `<!-- -->`, `#`),
shebangs and Go build constraints are preserved.

Excluded: generated Swagger docs (`server/api/admin/docs/docs.go`,
`server/api/user/docs/userapi_docs.go`).

Comments-only change; the build is unaffected.
