### PR TITLE
Post-v2.0.0 fixes: swagger, toasts, flow dialog polish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ embed-models: download-model
 	@echo "Models copied to server/models/"
 
 swagger:
-	@cd server && go run github.com/swaggo/swag/cmd/swag init --dir ./api/admin --generalInfo doc.go --output ./api/admin/docs --parseDependency --parseInternal
+	@cd server && go run github.com/swaggo/swag/cmd/swag init --dir ./api/admin --generalInfo doc.go --output ./api/admin/docs --parseDependency --parseInternal --templateDelims "[[,]]"
 	@echo "Admin API swagger generated in server/api/admin/docs/"
-	@cd server && go run github.com/swaggo/swag/cmd/swag init --dir ./api/user --generalInfo doc.go --output ./api/user/docs --parseDependency --parseInternal --instanceName userapi
+	@cd server && go run github.com/swaggo/swag/cmd/swag init --dir ./api/user --generalInfo doc.go --output ./api/user/docs --parseDependency --parseInternal --instanceName userapi --templateDelims "[[,]]"
 	@echo "User API swagger generated in server/api/user/docs/"
 
 dev: build

--- a/frontend/admin-ui/src/components/AppDialog.vue
+++ b/frontend/admin-ui/src/components/AppDialog.vue
@@ -18,7 +18,10 @@
       <div class="p-5 overflow-y-auto flex-1">
         <slot />
       </div>
-      <div class="flex justify-end gap-3 p-5 border-t border-piedra-700/50 flex-shrink-0">
+      <div
+        class="flex justify-end gap-3 p-5 flex-shrink-0"
+        :class="footerDivider ? 'border-t border-piedra-700/50' : 'pt-0'"
+      >
         <slot name="footer">
           <button type="button" @click="close" class="px-4 py-2 text-sm text-arena-400 hover:text-arena-200 hover:bg-piedra-800 rounded-lg transition-colors">
             Cancel
@@ -41,6 +44,10 @@ const props = defineProps({
   // persistent blocks the native <dialog> Escape-to-close so a heavy,
   // unsaved form (e.g. the flow editor) is only dismissed via Cancel/Save/X.
   persistent: { type: Boolean, default: false },
+  // footerDivider draws the border between the content area and the footer
+  // buttons. Dialogs whose content already ends in a strong visual block
+  // (e.g. the flow canvas) can switch it off.
+  footerDivider: { type: Boolean, default: true },
 })
 
 defineEmits(['close', 'save'])

--- a/frontend/admin-ui/src/components/Toast.vue
+++ b/frontend/admin-ui/src/components/Toast.vue
@@ -1,6 +1,16 @@
 <template>
-  <Teleport to="body">
-    <div class="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none">
+  <Teleport :to="teleportTarget">
+    <!--
+      Two tricks combined so toasts paint above AND stay clickable over modals:
+      1. popover="manual" promotes the stack to the browser top layer, above
+         any <dialog>.showModal() veil; plain z-index never wins against it.
+      2. showModal() makes everything outside the dialog's DOM subtree inert
+         (visible or not), so the stack teleports INTO the topmost open modal
+         while one exists and back to body when it closes — same lesson as
+         NodeHelp. Position is unaffected: the popover top layer + fixed
+         positioning resolve against the viewport from any DOM spot.
+    -->
+    <div ref="popRef" popover="manual" class="toast-pop fixed z-[9999] flex flex-col gap-2 pointer-events-none">
       <TransitionGroup
         enter-active-class="transition-all duration-300 ease-out"
         enter-from-class="translate-y-2 opacity-0"
@@ -12,29 +22,21 @@
         <div
           v-for="toast in toasts"
           :key="toast.id"
-          class="pointer-events-auto flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl border shadow-lg shadow-black/30 min-w-[240px] max-w-[360px]"
-          :class="toastClasses(toast.type)"
+          class="pointer-events-auto px-4 py-3 rounded-xl bg-piedra-800 shadow-lg shadow-black/30 min-w-[240px] max-w-[360px]"
         >
-          <div class="w-5 h-5 flex-shrink-0 flex items-center justify-center">
-            <svg v-if="toast.type === 'success'" class="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-            </svg>
-            <svg v-else-if="toast.type === 'error'" class="w-4 h-4 text-lava-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-            <svg v-else class="w-4 h-4 text-arena-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full flex-shrink-0" :class="dotClass(toast.type)" />
+            <span class="text-[11px] font-bold text-arena-300 flex-1">{{ headerLabel(toast.type) }}</span>
+            <button
+              @click="dismiss(toast.id)"
+              class="w-5 h-5 flex-shrink-0 flex items-center justify-center rounded-md hover:bg-piedra-700 transition-colors"
+            >
+              <svg class="w-3 h-3 text-arena-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
-          <p class="text-xs font-medium leading-snug flex-1">{{ toast.message }}</p>
-          <button
-            @click="dismiss(toast.id)"
-            class="w-5 h-5 flex-shrink-0 flex items-center justify-center rounded-md hover:bg-piedra-700/50 transition-colors"
-          >
-            <svg class="w-3 h-3 text-arena-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <p class="mt-1.5 text-xs font-medium leading-snug text-arena-400">{{ toast.message }}</p>
         </div>
       </TransitionGroup>
     </div>
@@ -42,18 +44,90 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 
 const toasts = ref([])
+const popRef = ref(null)
+const teleportTarget = ref(document.body)
 let nextId = 0
+let hideTimer = null
 
-function toastClasses(type) {
-  if (type === 'success') return 'bg-piedra-900 border-green-500/30 text-green-200'
-  if (type === 'error') return 'bg-piedra-900 border-lava-500/30 text-lava-200'
-  return 'bg-piedra-900 border-piedra-600/50 text-arena-200'
+// topmostModal returns the open modal dialog the stack should live in, or
+// null when none is open. DOM order approximates top-layer order well enough
+// here (stacked modals are rare in the admin UI).
+function topmostModal() {
+  const modals = document.querySelectorAll('dialog:modal')
+  return modals.length ? modals[modals.length - 1] : null
+}
+
+// retarget moves the stack into the topmost open modal (so it escapes the
+// inertness showModal() imposes on the rest of the document) or back to body.
+function retarget() {
+  const next = topmostModal() || document.body
+  if (next !== teleportTarget.value && next.isConnected) {
+    teleportTarget.value = next
+  }
+}
+
+// Dialogs announce open/close via ToggleEvent ('toggle') and close via
+// 'close'; neither bubbles, but capture listeners on the document still see
+// them. Retargeting on both keeps live toasts interactive when a modal opens
+// mid-toast and returns them to body when it closes.
+function onDialogToggle(e) {
+  if (e.target instanceof HTMLDialogElement) retarget()
+}
+onMounted(() => {
+  document.addEventListener('toggle', onDialogToggle, true)
+  document.addEventListener('close', onDialogToggle, true)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('toggle', onDialogToggle, true)
+  document.removeEventListener('close', onDialogToggle, true)
+})
+
+// Keep the popover in sync with the toast list: shown while there are toasts,
+// hidden when empty. Re-showing on every addition re-promotes the stack to the
+// top of the top layer (above any modal dialog currently open). Hiding waits
+// for the leave transition (200ms) so the last toast animates out. Browsers
+// without the Popover API fall back to the fixed/z-index positioning.
+watch(() => toasts.value.length, (len) => {
+  const el = popRef.value
+  if (!el || typeof el.showPopover !== 'function') return
+  clearTimeout(hideTimer)
+  if (len > 0) {
+    if (el.matches(':popover-open')) el.hidePopover()
+    el.showPopover()
+    return
+  }
+  hideTimer = setTimeout(() => {
+    if (el.matches(':popover-open')) el.hidePopover()
+  }, 250)
+})
+
+// Moving a shown popover in the DOM auto-hides it, so after every teleport
+// re-show it once Vue has finished moving the nodes.
+watch(teleportTarget, async () => {
+  await nextTick()
+  const el = popRef.value
+  if (!el || typeof el.showPopover !== 'function') return
+  if (toasts.value.length > 0 && !el.matches(':popover-open')) el.showPopover()
+})
+
+// dotClass picks the status dot color: Magec yellow for success/info, lava
+// for errors (an error announced in cheerful yellow would be lying).
+function dotClass(type) {
+  if (type === 'error') return 'bg-lava-400'
+  return 'bg-sol-400'
+}
+
+// headerLabel gives the toast header its short greeting per type.
+function headerLabel(type) {
+  if (type === 'error') return 'Ouch!'
+  return 'Hey!'
 }
 
 function show(message, type = 'info', duration = 3000) {
+  retarget()
   const id = ++nextId
   toasts.value.push({ id, message, type })
   if (duration > 0) {
@@ -72,3 +146,17 @@ function info(message) { show(message, 'info') }
 
 defineExpose({ show, success, error, info })
 </script>
+
+<style scoped>
+/* Reset the UA popover styles (inset: 0, margin: auto, border, canvas
+   background) and pin the stack to the bottom-right corner. Also applies in
+   browsers without the Popover API, where the element is always rendered. */
+.toast-pop {
+  inset: auto 1rem 1rem auto;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
+}
+</style>

--- a/frontend/admin-ui/src/views/flows/FlowCanvas.vue
+++ b/frontend/admin-ui/src/views/flows/FlowCanvas.vue
@@ -100,7 +100,7 @@
       </svg>
 
       <!-- START sentinel -->
-      <div class="flow-start" :style="{ left: startPos.x + 'px', top: startPos.y + 'px' }" @pointerdown.stop="onStartPointerDown" title="Drag to move. Drag from the dot to pick the entry node.">
+      <div class="flow-start" :class="{ 'flow-start-floating': startIsFloating }" :style="{ left: startPos.x + 'px', top: startPos.y + 'px' }" @pointerdown.stop="onStartPointerDown" title="Drag to move. Drag from the dot to pick the entry node.">
         <div class="flow-start-card">
           <div class="flow-start-ic">
             <svg class="w-3.5 h-3.5 text-rose-400" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
@@ -134,7 +134,6 @@
       <div class="text-center">
         <p class="text-sm font-medium text-arena-300">Build your workflow graph</p>
         <p class="text-[10px] text-arena-500 mt-1">Add nodes from the toolbar, then drag from a node's right port to another's left port to connect them.</p>
-        <p class="text-[10px] text-rose-400/80 mt-1.5">Drag from the <span class="font-semibold">Start</span> dot to the node where execution begins.</p>
       </div>
     </div>
 
@@ -519,7 +518,22 @@ function measurePorts() {
 
 // Recompute when the structure changes or the view transforms.
 watch([nodes, edges, scale, panX, panY], () => nextTick(measurePorts), { deep: true })
-onMounted(() => { nextTick(() => { measurePorts(); fitView() }) })
+
+// viewSize tracks the canvas element's real size reactively. The canvas is
+// mounted while the parent <dialog> is still closed (display: none), where
+// getBoundingClientRect() reports 0x0; the ResizeObserver fires when the
+// dialog opens and again on every fullscreen toggle or window resize.
+const viewSize = ref({ w: 0, h: 0 })
+let resizeObserver = null
+onMounted(() => {
+  nextTick(() => { measurePorts(); fitView() })
+  resizeObserver = new ResizeObserver((entries) => {
+    const box = entries[0]?.contentRect
+    if (box) viewSize.value = { w: box.width, h: box.height }
+  })
+  if (canvasRef.value) resizeObserver.observe(canvasRef.value)
+})
+onBeforeUnmount(() => resizeObserver?.disconnect())
 
 // ── full screen ──────────────────────────────────────────────────────────────
 // CSS-based full screen (a fixed overlay), not the native Fullscreen API, so we
@@ -617,7 +631,9 @@ const ghostPath = computed(() => {
 })
 
 // START sentinel position: the operator's placement (startX/startY) if set,
-// else pinned to the left of the entry node, else a default spot.
+// else pinned to the left of the entry node, else centred above the empty-state
+// message so the very first thing a new flow shows is Start hovering over the
+// onboarding text (dragging it or adding a node leaves this branch).
 const startPos = computed(() => {
   const g = graph.value
   if (typeof g.startX === 'number' && typeof g.startY === 'number') {
@@ -625,7 +641,23 @@ const startPos = computed(() => {
   }
   const entryNode = nodes.value.find(n => n.id === entry.value)
   if (entryNode) return { x: entryNode.x - 150, y: entryNode.y + 4 }
+  // viewSize is reactive (ResizeObserver), so this recomputes when the dialog
+  // actually opens and whenever the canvas changes size (fullscreen, resize).
+  if (viewSize.value.w) {
+    return {
+      x: Math.round((viewSize.value.w / 2 - panX.value) / scale.value - 45),
+      y: Math.round((viewSize.value.h / 2 - panY.value) / scale.value - 92),
+    }
+  }
   return { x: 40, y: 60 }
+})
+
+// The Start box bobs gently while it sits on the empty-state message (no
+// custom position, no nodes yet) to signal it is a live element, not decor.
+// Any interaction that leaves the default branch also stops the animation.
+const startIsFloating = computed(() => {
+  const g = graph.value
+  return !nodes.value.length && typeof g.startX !== 'number'
 })
 </script>
 
@@ -743,6 +775,19 @@ const startPos = computed(() => {
 /* START sentinel */
 .flow-start { position: absolute; cursor: grab; }
 .flow-start:active { cursor: grabbing; }
+
+/* Gentle idle bobbing for the empty-state Start box: a hint that the box is
+   draggable and real. transform only (left/top stay untouched), so dragging
+   and port-anchor math are unaffected; the animation class simply drops off
+   once a node exists or the box has been placed. */
+@keyframes flow-start-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-7px); }
+}
+.flow-start-floating {
+  animation: flow-start-bob 2.4s ease-in-out infinite;
+}
+.flow-start-floating:active { animation: none; }
 .flow-start-card {
   display: flex;
   align-items: center;

--- a/frontend/admin-ui/src/views/flows/FlowCanvas.vue
+++ b/frontend/admin-ui/src/views/flows/FlowCanvas.vue
@@ -633,7 +633,7 @@ const startPos = computed(() => {
 .flow-canvas {
   position: relative;
   width: 100%;
-  height: 520px;
+  height: 340px;
   overflow: hidden;
   border-radius: 0.75rem;
   border: 1px solid rgba(120, 113, 108, 0.25);
@@ -665,9 +665,31 @@ const startPos = computed(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  backdrop-filter: blur(3px);
+  /* Heavy spread: nodes dissolve into soft color blobs, keeping only a hint
+     of what lives inside; saturate lifts the colors the blur washes out. */
+  backdrop-filter: blur(28px) saturate(1.6);
   background: rgba(24, 24, 27, 0.35);
   border-radius: inherit;
+  overflow: hidden;
+}
+
+/* Decorative aurora so the frosted glass always has color to diffuse, even
+   over an empty graph: soft radial blobs in the Magec palette (sol,
+   atlantico, rose, purple, green), melted together by their own blur. Real
+   nodes still shine through from behind and add their glow on top of it. */
+.flow-canvas-veil::before {
+  content: '';
+  position: absolute;
+  inset: -40px;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(38% 55% at 12% 20%, rgba(250, 204, 21, 0.28), transparent 70%),
+    radial-gradient(45% 60% at 85% 15%, rgba(56, 189, 248, 0.26), transparent 70%),
+    radial-gradient(40% 55% at 25% 85%, rgba(251, 113, 133, 0.24), transparent 70%),
+    radial-gradient(45% 60% at 75% 80%, rgba(192, 132, 252, 0.22), transparent 70%),
+    radial-gradient(35% 50% at 50% 45%, rgba(74, 222, 128, 0.16), transparent 70%);
+  filter: blur(34px) saturate(1.4);
 }
 
 .flow-canvas-veil-btn {

--- a/frontend/admin-ui/src/views/flows/FlowDialog.vue
+++ b/frontend/admin-ui/src/views/flows/FlowDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Flow' : 'New Flow'" size="2xl" persistent @save="save">
+  <AppDialog ref="dialogRef" :title="isEdit ? 'Edit Flow' : 'New Flow'" size="xl" persistent :footer-divider="false" @save="save">
     <div class="space-y-4">
       <div class="grid grid-cols-3 gap-4">
         <div>
@@ -22,30 +22,6 @@
       </div>
 
       <FlowCanvas v-model="form.graph" :agents="store.agents" :flows="availableSubflows" />
-
-      <details class="group text-arena-500">
-        <summary class="text-[10px] font-medium cursor-pointer select-none hover:text-arena-300 transition-colors">
-          How does the flow editor work?
-        </summary>
-        <div class="mt-2 text-[10px] leading-relaxed space-y-2 text-arena-500/80">
-          <p>A flow is a <span class="text-arena-300 font-semibold">graph</span>: add nodes from the toolbar, then drag from a node's right port to another node's left port to connect them. Drag from <span class="text-rose-400 font-semibold">Start</span> to the node where execution begins.</p>
-          <div class="grid grid-cols-3 gap-x-4 gap-y-1.5">
-            <div><span class="text-sol-400 font-semibold">Agent</span> — an AI agent that processes input and produces output.</div>
-            <div><span class="text-atlantico-400 font-semibold">Router</span> — evaluates CEL rules in order and routes to one branch.</div>
-            <div><span class="text-purple-400 font-semibold">Join</span> — waits for all incoming branches, then forwards their combined output.</div>
-          </div>
-          <div class="flex items-start gap-1.5 pt-1 border-t border-piedra-700/30">
-            <svg class="w-3.5 h-3.5 text-green-400 flex-shrink-0 mt-px" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.2 48.2 0 0 0 5.887-.512c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.4 48.4 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
-            </svg>
-            <span>Each agent has a <span class="text-green-400 font-semibold">response</span> toggle. Only agents with this active are included in the flow output. If none are marked, all agent outputs are returned.</span>
-          </div>
-          <div class="pt-1 border-t border-piedra-700/30 space-y-1">
-            <p>Agents in a flow share a <span class="text-arena-300 font-semibold">state</span> map via <code class="text-arena-300">set_state(key, value)</code> and <code class="text-arena-300">get_state(key)</code>. A <span class="text-atlantico-400 font-semibold">router</span>'s CEL rules read that state as <code class="text-arena-300">state.key</code> and the loop counter as <code class="text-arena-300">iterations</code>, e.g. <code class="text-arena-300">state.done || iterations >= 5</code>.</p>
-            <p>To build a <span class="text-atlantico-400 font-semibold">loop</span>, draw an edge from a router's route back to an earlier node; the other route leaves the loop.</p>
-          </div>
-        </div>
-      </details>
     </div>
   </AppDialog>
 </template>

--- a/server/api/admin/docs/docs.go
+++ b/server/api/admin/docs/docs.go
@@ -4,16 +4,16 @@ package docs
 import "github.com/swaggo/swag"
 
 const docTemplate = `{
-    "schemes": {{ marshal .Schemes }},
+    "schemes": [[ marshal .Schemes ]],
     "swagger": "2.0",
     "info": {
-        "description": "{{escape .Description}}",
-        "title": "{{.Title}}",
+        "description": "[[escape .Description]]",
+        "title": "[[.Title]]",
         "contact": {},
-        "version": "{{.Version}}"
+        "version": "[[.Version]]"
     },
-    "host": "{{.Host}}",
-    "basePath": "{{.BasePath}}",
+    "host": "[[.Host]]",
+    "basePath": "[[.BasePath]]",
     "paths": {
         "/agents": {
             "get": {
@@ -3377,9 +3377,6 @@ const docTemplate = `{
                     "description": "AgentID references an AgentDefinition by ID. Required when Type is\nFlowNodeAgent (the agent to run) or FlowNodeParallel (the agent run once\nper list item). Ignored for other types.",
                     "type": "string"
                 },
-                "defaultRoute": {
-                    "type": "string"
-                },
                 "expression": {
                     "description": "Expression is a CEL expression evaluated over ` + "`" + `input` + "`" + ` (the previous\nnode's output) and ` + "`" + `state` + "`" + ` (the shared flow state). Its result becomes\nthis node's output. Required when Type is FlowNodeExpression.",
                     "type": "string"
@@ -3411,7 +3408,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "rules": {
-                    "description": "Rules and DefaultRoute drive a router node. Rules are evaluated in order;\nDefaultRoute is emitted when no rule matches. Only meaningful when Type\nis FlowNodeRouter.",
+                    "description": "Rules drive a router node, evaluated in order; when none matches the\nrouter emits RouterOtherwiseRoute. Only meaningful when Type\nis FlowNodeRouter.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/store.FlowRule"
@@ -3755,8 +3752,8 @@ var SwaggerInfo = &swag.Spec{
 	Description:      "Administration API for managing Magec resources.\nWhen server.adminPassword is configured, all /api/ endpoints require a Bearer token.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
-	LeftDelim:        "{{",
-	RightDelim:       "}}",
+	LeftDelim:        "[[",
+	RightDelim:       "]]",
 }
 
 func init() {

--- a/server/api/admin/docs/docs_render_test.go
+++ b/server/api/admin/docs/docs_render_test.go
@@ -1,0 +1,37 @@
+package docs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/swaggo/swag"
+)
+
+// TestReadDocRendersValidJSON is a canary for a subtle swaggo failure mode:
+// when a Go doc comment copied into the swagger template contains literal
+// template delimiters (e.g. the `{{ input }}` flow placeholders documented
+// on store.FlowNode), template parsing fails and swag silently serves the
+// RAW template, showing `{{.Version}}` and friends in the Swagger UI.
+// Rendering must produce valid JSON with the info block actually expanded.
+func TestReadDocRendersValidJSON(t *testing.T) {
+	doc, err := swag.ReadDoc(SwaggerInfo.InstanceName())
+	if err != nil {
+		t.Fatalf("ReadDoc(%q) failed: %v", SwaggerInfo.InstanceName(), err)
+	}
+
+	var rendered struct {
+		Info struct {
+			Version string `json:"version"`
+			Title   string `json:"title"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal([]byte(doc), &rendered); err != nil {
+		t.Fatalf("rendered swagger doc is not valid JSON (raw template served?): %v", err)
+	}
+	if rendered.Info.Version != SwaggerInfo.Version {
+		t.Fatalf("info.version = %q, want %q (placeholder not expanded)", rendered.Info.Version, SwaggerInfo.Version)
+	}
+	if rendered.Info.Title != SwaggerInfo.Title {
+		t.Fatalf("info.title = %q, want %q (placeholder not expanded)", rendered.Info.Title, SwaggerInfo.Title)
+	}
+}

--- a/server/api/admin/docs/swagger.json
+++ b/server/api/admin/docs/swagger.json
@@ -3374,9 +3374,6 @@
                     "description": "AgentID references an AgentDefinition by ID. Required when Type is\nFlowNodeAgent (the agent to run) or FlowNodeParallel (the agent run once\nper list item). Ignored for other types.",
                     "type": "string"
                 },
-                "defaultRoute": {
-                    "type": "string"
-                },
                 "expression": {
                     "description": "Expression is a CEL expression evaluated over `input` (the previous\nnode's output) and `state` (the shared flow state). Its result becomes\nthis node's output. Required when Type is FlowNodeExpression.",
                     "type": "string"
@@ -3408,7 +3405,7 @@
                     "type": "boolean"
                 },
                 "rules": {
-                    "description": "Rules and DefaultRoute drive a router node. Rules are evaluated in order;\nDefaultRoute is emitted when no rule matches. Only meaningful when Type\nis FlowNodeRouter.",
+                    "description": "Rules drive a router node, evaluated in order; when none matches the\nrouter emits RouterOtherwiseRoute. Only meaningful when Type\nis FlowNodeRouter.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/store.FlowRule"

--- a/server/api/admin/docs/swagger.yaml
+++ b/server/api/admin/docs/swagger.yaml
@@ -408,8 +408,6 @@ definitions:
           FlowNodeAgent (the agent to run) or FlowNodeParallel (the agent run once
           per list item). Ignored for other types.
         type: string
-      defaultRoute:
-        type: string
       expression:
         description: |-
           Expression is a CEL expression evaluated over `input` (the previous
@@ -453,8 +451,8 @@ definitions:
         type: boolean
       rules:
         description: |-
-          Rules and DefaultRoute drive a router node. Rules are evaluated in order;
-          DefaultRoute is emitted when no rule matches. Only meaningful when Type
+          Rules drive a router node, evaluated in order; when none matches the
+          router emits RouterOtherwiseRoute. Only meaningful when Type
           is FlowNodeRouter.
         items:
           $ref: '#/definitions/store.FlowRule'

--- a/server/api/user/docs/docs_render_test.go
+++ b/server/api/user/docs/docs_render_test.go
@@ -1,0 +1,36 @@
+package docs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/swaggo/swag"
+)
+
+// TestReadDocRendersValidJSON is a canary for a subtle swaggo failure mode:
+// when a Go doc comment copied into the swagger template contains literal
+// template delimiters, template parsing fails and swag silently serves the
+// RAW template, showing `{{.Version}}` and friends in the Swagger UI.
+// Rendering must produce valid JSON with the info block actually expanded.
+func TestReadDocRendersValidJSON(t *testing.T) {
+	doc, err := swag.ReadDoc(SwaggerInfouserapi.InstanceName())
+	if err != nil {
+		t.Fatalf("ReadDoc(%q) failed: %v", SwaggerInfouserapi.InstanceName(), err)
+	}
+
+	var rendered struct {
+		Info struct {
+			Version string `json:"version"`
+			Title   string `json:"title"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal([]byte(doc), &rendered); err != nil {
+		t.Fatalf("rendered swagger doc is not valid JSON (raw template served?): %v", err)
+	}
+	if rendered.Info.Version != SwaggerInfouserapi.Version {
+		t.Fatalf("info.version = %q, want %q (placeholder not expanded)", rendered.Info.Version, SwaggerInfouserapi.Version)
+	}
+	if rendered.Info.Title != SwaggerInfouserapi.Title {
+		t.Fatalf("info.title = %q, want %q (placeholder not expanded)", rendered.Info.Title, SwaggerInfouserapi.Title)
+	}
+}

--- a/server/api/user/docs/userapi_docs.go
+++ b/server/api/user/docs/userapi_docs.go
@@ -4,16 +4,16 @@ package docs
 import "github.com/swaggo/swag"
 
 const docTemplateuserapi = `{
-    "schemes": {{ marshal .Schemes }},
+    "schemes": [[ marshal .Schemes ]],
     "swagger": "2.0",
     "info": {
-        "description": "{{escape .Description}}",
-        "title": "{{.Title}}",
+        "description": "[[escape .Description]]",
+        "title": "[[.Title]]",
         "contact": {},
-        "version": "{{.Version}}"
+        "version": "[[.Version]]"
     },
-    "host": "{{.Host}}",
-    "basePath": "{{.BasePath}}",
+    "host": "[[.Host]]",
+    "basePath": "[[.BasePath]]",
     "paths": {
         "/a2a/.well-known/agent-card.json": {
             "get": {
@@ -1545,8 +1545,8 @@ var SwaggerInfouserapi = &swag.Spec{
 	Description:      "User-facing API for Magec. Includes device pairing, voice proxies, and health checks.",
 	InfoInstanceName: "userapi",
 	SwaggerTemplate:  docTemplateuserapi,
-	LeftDelim:        "{{",
-	RightDelim:       "}}",
+	LeftDelim:        "[[",
+	RightDelim:       "]]",
 }
 
 func init() {


### PR DESCRIPTION
Small fixes and UI polish spotted after the v2.0.0 release.

- **Swagger rendered raw.** The doc comment on \`FlowNode.Template\` contains literal \`{{ input }}\` placeholders; swag copies doc comments into the Go template it renders at runtime, parsing failed and swaggo silently served the raw template (\`{{.Version}}\` visible in the UI). Specs now generate with custom delims \`[[,]]\`, plus canary tests that fail if the rendered doc stops being valid JSON.
- **Toasts fixed and restyled.** They rendered behind modal dialogs (top layer beats z-index) and their dismiss button was inert. Now a manual popover that relocates inside the open dialog, styled to the house look: opaque card, status dot, bold greeting header.
- **FlowDialog slimmed down.** The minimized canvas is a teaser, not a workspace: shorter (340px) frosted-glass preview with an aurora backdrop, dialog narrowed to xl, stale help accordion removed, optional footer divider (off here).
- **Start box onboarding.** On an empty canvas, Start floats centred above the welcome text with a gentle bob, so it reads as draggable instead of decoration.