### PR TITLE
fix: client info advertised deleted agents as default

### DIFF
--- a/server/api/user/handlers.go
+++ b/server/api/user/handlers.go
@@ -120,9 +120,12 @@ func (h *Handler) ClientInfo(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// The default must come from the validated list, not the raw store list:
+	// AllowedAgents may hold IDs of agents/flows deleted after the client was
+	// configured, and pointing a UI at a ghost breaks every voice/run call.
 	defaultAgent := ""
-	if len(cl.AllowedAgents) > 0 {
-		defaultAgent = cl.AllowedAgents[0]
+	if len(allowedDetails) > 0 {
+		defaultAgent = allowedDetails[0].ID
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(ClientInfoResponse{

--- a/server/api/user/handlers_test.go
+++ b/server/api/user/handlers_test.go
@@ -1,0 +1,99 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package user
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/achetronic/magec/server/store"
+)
+
+// newTestStore builds an empty file-backed store in a temp dir.
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.New(filepath.Join(t.TempDir(), "store.json"), "")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	return s
+}
+
+// TestClientInfo_DefaultAgentSkipsStaleReferences is a canary for a real bug:
+// a client whose allowedAgents list began with the ID of a deleted agent
+// advertised that ghost as defaultAgent, so UIs following it aimed every
+// voice/run call at a 404. The default must come from the validated list.
+func TestClientInfo_DefaultAgentSkipsStaleReferences(t *testing.T) {
+	s := newTestStore(t)
+
+	agent, err := s.CreateAgent(store.AgentDefinition{Name: "Live Agent"})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	client, err := s.CreateClient(store.ClientDefinition{
+		Name: "ui",
+		Type: "direct",
+		// First entry references an agent that no longer exists.
+		AllowedAgents: []string{"deadbeef-0000-0000-0000-000000000000", agent.ID},
+	})
+	if err != nil {
+		t.Fatalf("CreateClient: %v", err)
+	}
+
+	h := New(s)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/client/info", nil)
+	req.Header.Set("X-Client-ID", client.ID)
+	rec := httptest.NewRecorder()
+	h.ClientInfo(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp ClientInfoResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.DefaultAgent != agent.ID {
+		t.Fatalf("defaultAgent = %q, want live agent %q (stale reference must be skipped)", resp.DefaultAgent, agent.ID)
+	}
+	if len(resp.AllowedAgents) != 1 || resp.AllowedAgents[0].ID != agent.ID {
+		t.Fatalf("allowedAgents = %+v, want only the live agent", resp.AllowedAgents)
+	}
+}
+
+// TestClientInfo_DefaultAgentEmptyWhenNothingResolves: a client whose every
+// reference is stale must advertise no default at all rather than a ghost.
+func TestClientInfo_DefaultAgentEmptyWhenNothingResolves(t *testing.T) {
+	s := newTestStore(t)
+
+	client, err := s.CreateClient(store.ClientDefinition{
+		Name:          "ui",
+		Type:          "direct",
+		AllowedAgents: []string{"deadbeef-0000-0000-0000-000000000000"},
+	})
+	if err != nil {
+		t.Fatalf("CreateClient: %v", err)
+	}
+
+	h := New(s)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/client/info", nil)
+	req.Header.Set("X-Client-ID", client.ID)
+	rec := httptest.NewRecorder()
+	h.ClientInfo(rec, req)
+
+	var resp ClientInfoResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.DefaultAgent != "" {
+		t.Fatalf("defaultAgent = %q, want empty when nothing resolves", resp.DefaultAgent)
+	}
+}


### PR DESCRIPTION
A client whose allowed-agents list starts with the ID of a deleted agent or flow kept advertising that ghost as `defaultAgent` in `/api/v1/client/info`: the allowed list is validated against live entities, but the default was taken from the raw store list. The Voice UI followed it and aimed every transcription call at a 404, so STT looked broken while the backend was perfectly healthy.

The default now comes from the first entry of the validated list (empty when nothing resolves), with canary tests for both cases.