### PR TITLE
docs: living docs catch up with the integrity feature

### DIFF
--- a/.agents/ADMIN_UI_DESIGN_SYSTEM.md
+++ b/.agents/ADMIN_UI_DESIGN_SYSTEM.md
@@ -318,3 +318,17 @@ above dialogs AND stay clickable — see decision #35 before touching it.
 - `footerDivider` (default `true`): border between content and the Cancel/Save
   row. Turn off when the content already ends in a strong visual block (the
   flow canvas preview); keep on for scrolling forms.
+
+## Delete Confirmations (`ConfirmDialog`, `ForceDeleteDialog`, `ReferenceListDialog`)
+
+Deletes go through `deleteEntity()` (provided by App.vue), never raw
+`requestDelete` + api calls in views:
+
+- `deleteEntity({message, label, doDelete, after})` shows the standard
+  ConfirmDialog; when the API answers `409` with a reference breakdown, it
+  chains a `ForceDeleteDialog` and retries `doDelete(true)` on confirm.
+- `ReferenceListDialog` is the shared shell for "these entities are affected"
+  lists (title/subtitle/rows/confirm props; rows are display-ready). Both
+  `ForceDeleteDialog` (lava rows for structural damage, arena for harmless
+  unlinks) and the Settings Maintenance cleanup (blue rows) build on it.
+  New affected-entities dialogs must reuse it, not clone the row markup.

--- a/.agents/MULTI_AGENT_ADMIN_API.md
+++ b/.agents/MULTI_AGENT_ADMIN_API.md
@@ -34,7 +34,7 @@ Store (in-memory + JSON persistence → data/store.json)
 │   ├── id, name, description, prompt
 ├── Flows[]             — multi-agent workflows
 │   ├── id, name, description
-│   ├── root: FlowStep (recursive tree with responseAgent flag)
+│   ├── entry, nodes[], edges[]  — directed graph (agent, router, join, parallel, subflow, expression, template, code)
 │   └── a2a: {enabled}  — exposes flow via A2A protocol
 ├── Secrets[]           — encrypted key-value pairs for env var injection
 │   ├── id, name, key, value, description
@@ -52,6 +52,31 @@ Backends (AI infra) → Memory (data infra) → MCPs (tools) → Skills (knowled
 ## API Reference
 
 Base path: `/api/v1/admin`. All endpoints return JSON. Errors: `{"error": "message"}`.
+
+### Deletes and referential integrity
+
+Every entity `DELETE` runs a shared guard (decision #36). Deleting an entity
+still referenced by others returns `409` with the breakdown:
+
+```json
+{"error": "entity is referenced by other entities",
+ "references": [{"referrerType": "client", "referrerId": "...", "referrerName": "UI",
+                 "field": "allowedAgents", "kind": "membership"}]}
+```
+
+`kind` is `membership` (list entries, optional fields — scrubbing is harmless)
+or `structural` (flow nodes, `llm.backend`, cron/webhook `commandId` —
+scrubbing breaks the referrer). Repeating the `DELETE` with `?force=true`
+scrubs every reference in one transaction and proceeds.
+
+| Method | Path                                | Description                                              |
+| ------ | ----------------------------------- | -------------------------------------------------------- |
+| GET    | `/integrity/dead-references`        | References whose target no longer exists                 |
+| POST   | `/integrity/dead-references/clean`  | Scrub every dead reference, returns `{"removed": n}`     |
+
+Backs the Settings → Maintenance → Scan & Clean button. Readers report the
+store as it is: dead references are fixed by cleaning, never worked around
+on read.
 
 ### Backends
 


### PR DESCRIPTION
The API reference still described flows as the pre-v2 recursive tree and knew nothing about the delete guard. Now it documents the graph data model, the 409 reference breakdown with `?force=true`, and the `/integrity` endpoints; the design system records the `deleteEntity()` flow and the shared `ReferenceListDialog`.