### PR TITLE
fix: flow runs failed on Ollama and strict chat templates

### DIFF
--- a/server/agent/tools/flowstate/toolset.go
+++ b/server/agent/tools/flowstate/toolset.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/tool"
 	"google.golang.org/adk/v2/tool/functiontool"
@@ -37,7 +38,7 @@ const StateKeyPrefix = "flow:"
 // keyPattern matches the subset of key names we accept from the LLM. It
 // rules out colons (which would let the model escape the namespace into
 // "app:" or "user:" tiers) and any character that is not a typical
-// identifier. The pattern is intentionally restrictive — flow-shared state
+// identifier. The pattern is intentionally restrictive: flow-shared state
 // is not meant to carry structured paths.
 var keyPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
@@ -46,6 +47,14 @@ var keyPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 // regardless of the flow shape (sequential, parallel, loop, or nested).
 type Toolset struct {
 	tools []tool.Tool
+}
+
+// anyValueSchema describes a value of any JSON type as an explicit union.
+// Schemas inferred from `any` fields become the boolean schema `true`, which
+// Ollama's request parser rejects and strict jinja chat templates choke on.
+var anyValueSchema = &jsonschema.Schema{
+	Types:       []string{"string", "number", "integer", "boolean", "array", "object", "null"},
+	Description: "The value to store. Any JSON type is accepted.",
 }
 
 // NewToolset builds the set_state/get_state tools. The toolset is stateless
@@ -60,6 +69,14 @@ func NewToolset() (*Toolset, error) {
 				"Keys must be simple identifiers (letters, digits, underscores). " +
 				"Values can be strings, numbers, booleans, lists or objects. " +
 				"State persists for the duration of the conversation and is visible to every other agent in the same flow.",
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"key":   {Type: "string", Description: "Identifier: letters, digits, underscores."},
+					"value": anyValueSchema,
+				},
+				Required: []string{"key", "value"},
+			},
 		},
 		setState,
 	)
@@ -73,6 +90,16 @@ func NewToolset() (*Toolset, error) {
 			Description: "Read a value previously stored in the shared flow state by another agent (or by an earlier turn of this agent). " +
 				"Returns {found: true, value: ...} when the key exists and {found: false} when it does not. " +
 				"Use this to check signals, decisions or intermediate results produced by upstream agents.",
+			// Explicit because GetResult.Value is `any`; see anyValueSchema.
+			OutputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"found":   {Type: "boolean", Description: "Whether the key exists in the flow state."},
+					"value":   anyValueSchema,
+					"message": {Type: "string", Description: "Optional validation message."},
+				},
+				Required: []string{"found"},
+			},
 		},
 		getState,
 	)
@@ -147,7 +174,7 @@ type GetResult struct {
 
 // getState reads args.Key from the session state. We go through
 // tool.Context.State() rather than ReadonlyState() so the lookup observes
-// values written in the current event's StateDelta — i.e. a get_state
+// values written in the current event's StateDelta, i.e. a get_state
 // after a set_state inside the same turn returns the freshly written
 // value, not the pre-event one. A missing key is not an error: it returns
 // {found: false} so the model can branch on absence without spurious

--- a/server/agent/tools/flowstate/toolset_test.go
+++ b/server/agent/tools/flowstate/toolset_test.go
@@ -10,12 +10,14 @@ package flowstate
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"iter"
 	"testing"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 )
 
 // fakeState is a tiny session.State implementation backed by a map. It
@@ -192,4 +194,103 @@ func TestNewToolset_RegistersBothTools(t *testing.T) {
 	if !names["set_state"] || !names["get_state"] {
 		t.Fatalf("expected set_state and get_state, got %v", names)
 	}
+}
+
+// declarationOf digs the genai FunctionDeclaration out of a tool via the
+// unexported runnableTool shape adk uses.
+func declarationOf(t *testing.T, tl any) *genai.FunctionDeclaration {
+	t.Helper()
+	d, ok := tl.(interface {
+		Declaration() *genai.FunctionDeclaration
+	})
+	if !ok {
+		t.Fatalf("tool %T does not expose Declaration()", tl)
+	}
+	return d.Declaration()
+}
+
+// schemaAsMap marshals a declared schema and requires it to be a JSON object
+// at the top level.
+func schemaAsMap(t *testing.T, name string, schema any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("%s: marshal schema: %v", name, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("%s: schema is not an object (boolean schema at top level?): %v", name, err)
+	}
+	return m
+}
+
+// assertNoBooleanProperties fails when any property of the schema is not an
+// object schema.
+func assertNoBooleanProperties(t *testing.T, name string, m map[string]any) {
+	t.Helper()
+	props, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: schema has no properties object: %v", name, m)
+	}
+	for propName, prop := range props {
+		if _, ok := prop.(map[string]any); !ok {
+			t.Errorf("%s: property %q is not an object schema (got %T: %v) - boolean schemas break Ollama and strict jinja templates", name, propName, prop, prop)
+		}
+	}
+}
+
+// TestSchemas_NoBooleanProperties: every property of every flowstate tool
+// schema, input and output, must be an object schema.
+func TestSchemas_NoBooleanProperties(t *testing.T) {
+	ts, err := NewToolset()
+	if err != nil {
+		t.Fatalf("NewToolset: %v", err)
+	}
+	tools, err := ts.Tools(nil)
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	for _, tl := range tools {
+		decl := declarationOf(t, tl)
+		if decl.ParametersJsonSchema != nil {
+			assertNoBooleanProperties(t, tl.Name()+" input", schemaAsMap(t, tl.Name(), decl.ParametersJsonSchema))
+		}
+		if decl.ResponseJsonSchema != nil {
+			assertNoBooleanProperties(t, tl.Name()+" output", schemaAsMap(t, tl.Name(), decl.ResponseJsonSchema))
+		}
+		if decl.ParametersJsonSchema == nil && decl.ResponseJsonSchema == nil {
+			t.Errorf("%s: declaration exposes no schemas at all", tl.Name())
+		}
+	}
+}
+
+// TestSetStateSchema_ValueAcceptsEveryJSONType: the explicit union must
+// accept every JSON type.
+func TestSetStateSchema_ValueAcceptsEveryJSONType(t *testing.T) {
+	ts, _ := NewToolset()
+	tools, _ := ts.Tools(nil)
+	for _, tl := range tools {
+		if tl.Name() != "set_state" {
+			continue
+		}
+		schema := schemaAsMap(t, "set_state", declarationOf(t, tl).ParametersJsonSchema)
+		props := schema["properties"].(map[string]any)
+		value, ok := props["value"].(map[string]any)
+		if !ok {
+			t.Fatalf("value is not an object schema: %v", props["value"])
+		}
+		types, ok := value["type"].([]any)
+		if !ok {
+			t.Fatalf("value.type is not a union: %v", value["type"])
+		}
+		want := map[string]bool{"string": true, "number": true, "integer": true, "boolean": true, "array": true, "object": true, "null": true}
+		for _, tp := range types {
+			delete(want, tp.(string))
+		}
+		if len(want) != 0 {
+			t.Fatalf("value.type union is missing %v", want)
+		}
+		return
+	}
+	t.Fatal("set_state tool not found")
 }


### PR DESCRIPTION
Fixes #51.

Agents worked in direct chat but every flow run failed in under half a second on Ollama backends and on several models behind llama-server (Qwen, Nemotron), while Phi and Gemma 12B worked. The trigger was the `set_state` tool, which is only injected inside flows.

- **Root cause.** The tool's schema was inferred from a Go struct whose `value` field accepts anything; the schema library renders that as the JSON Schema boolean `"value": true`. That form is spec-legal, but Ollama's request parser rejects the entire call with a 400 before even resolving the model, and strict jinja chat templates break while rendering the tool block. Tolerant templates explain why some models appeared to work.
- **The fix.** `set_state` now declares its schema explicitly, describing `value` as the conventional union of every JSON type. Same meaning, universally parseable. Verified live against Ollama with the same model and prompt: old schema fails at parse time, new schema completes.
- **A canary test** rejects boolean properties in the flow tool schemas so this cannot regress silently.