### PR TITLE
fix: large tool responses no longer kill the SSE stream

### DIFF
--- a/server/clients/msgutil/sse.go
+++ b/server/clients/msgutil/sse.go
@@ -61,58 +61,71 @@ type UsageMetadata struct {
 }
 
 // ParseSSEStream reads a /run_sse response body and calls handler for each
-// meaningful event as it arrives. The handler receives events one at a time.
-// This is a blocking call that returns when the stream ends or an error occurs.
+// event as it arrives, blocking until the stream ends. It reads with a growing
+// buffered reader because one data: line can carry an unbounded event payload.
 func ParseSSEStream(reader io.Reader, handler func(SSEEvent)) error {
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+	br := bufio.NewReaderSize(reader, 64*1024)
 
 	const adkErrorPrefix = "Error while running agent: "
 
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if strings.HasPrefix(line, adkErrorPrefix) {
-			errMsg := strings.TrimPrefix(line, adkErrorPrefix)
-			slog.Error("SSE stream: ADK agent error received as plain text",
-				"error", errMsg,
-			)
-			handler(SSEEvent{
-				Type:         SSEEventError,
-				ErrorMessage: errMsg,
-			})
-			continue
+	for {
+		line, err := br.ReadString('\n')
+		// The stream may end without a trailing newline; the residual line
+		// still carries the last event.
+		if line != "" {
+			line = strings.TrimRight(line, "\r\n")
+			handleSSELine(line, adkErrorPrefix, handler)
 		}
-
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-
-		data := strings.TrimPrefix(line, "data: ")
-		if data == "" {
-			continue
-		}
-
-		var raw map[string]interface{}
-		if err := json.Unmarshal([]byte(data), &raw); err != nil {
-			continue
-		}
-
-		events := classifyEvent(raw)
-		if len(events) == 0 {
-			author, _ := raw["author"].(string)
-			slog.Debug("SSE event dropped (no classifiable parts)",
-				"author", author,
-				"raw_keys", mapKeys(raw),
-				"data_len", len(data),
-			)
-		}
-		for _, evt := range events {
-			handler(evt)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
 		}
 	}
+}
 
-	return scanner.Err()
+// handleSSELine dispatches one SSE line: ADK plain-text errors, data: frames
+// with JSON events, everything else ignored.
+func handleSSELine(line, adkErrorPrefix string, handler func(SSEEvent)) {
+	if strings.HasPrefix(line, adkErrorPrefix) {
+		errMsg := strings.TrimPrefix(line, adkErrorPrefix)
+		slog.Error("SSE stream: ADK agent error received as plain text",
+			"error", errMsg,
+		)
+		handler(SSEEvent{
+			Type:         SSEEventError,
+			ErrorMessage: errMsg,
+		})
+		return
+	}
+
+	if !strings.HasPrefix(line, "data: ") {
+		return
+	}
+
+	data := strings.TrimPrefix(line, "data: ")
+	if data == "" {
+		return
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(data), &raw); err != nil {
+		return
+	}
+
+	events := classifyEvent(raw)
+	if len(events) == 0 {
+		author, _ := raw["author"].(string)
+		slog.Debug("SSE event dropped (no classifiable parts)",
+			"author", author,
+			"raw_keys", mapKeys(raw),
+			"data_len", len(data),
+		)
+	}
+	for _, evt := range events {
+		handler(evt)
+	}
 }
 
 // classifyEvent examines a raw ADK event JSON and returns one or more typed SSEEvents.

--- a/server/clients/msgutil/sse_test.go
+++ b/server/clients/msgutil/sse_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Alberto Hernández
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package msgutil
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestParseSSEStream_LargeToolResponse: a multi-megabyte data: line parses instead of dropping the stream.
+func TestParseSSEStream_LargeToolResponse(t *testing.T) {
+	payload := map[string]any{
+		"author": "agent_1",
+		"content": map[string]any{
+			"parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name":     "get_logs",
+					"response": strings.Repeat("x", 5*1024*1024),
+				}},
+			},
+		},
+	}
+	line, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	body := "data: " + string(line) + "\n\ndata: {\"author\":\"agent_1\",\"turn_complete\":true,\"finish_reason\":\"STOP\"}\n"
+
+	var got []SSEEvent
+	if err := ParseSSEStream(strings.NewReader(body), func(e SSEEvent) { got = append(got, e) }); err != nil {
+		t.Fatalf("ParseSSEStream: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("events = %d, want tool result + turn_complete", len(got))
+	}
+	if got[0].Type != SSEEventToolResult || got[0].ToolName != "get_logs" {
+		t.Fatalf("first event = %+v, want the large tool result", got[0])
+	}
+	if s, ok := got[0].ToolResult.(string); !ok || len(s) != 5*1024*1024 {
+		t.Fatalf("tool result truncated or mistyped")
+	}
+	if !got[1].TurnComplete {
+		t.Fatalf("events after the large line were lost")
+	}
+}
+
+// TestParseSSEStream_NoTrailingNewline: the last event survives a stream with no final newline.
+func TestParseSSEStream_NoTrailingNewline(t *testing.T) {
+	body := `data: {"author":"agent_1","content":{"parts":[{"text":"hi"}]}}`
+
+	var got []SSEEvent
+	if err := ParseSSEStream(strings.NewReader(body), func(e SSEEvent) { got = append(got, e) }); err != nil {
+		t.Fatalf("ParseSSEStream: %v", err)
+	}
+	if len(got) != 1 || got[0].Type != SSEEventText || got[0].Text != "hi" {
+		t.Fatalf("events = %+v, want the single text event", got)
+	}
+}
+
+// TestParseSSEStream_HappyPath: text, comments, blanks, CRLF and ADK plain-text errors dispatch correctly.
+func TestParseSSEStream_HappyPath(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"author":"agent_1","content":{"parts":[{"text":"hello "}]}}`,
+		``,
+		`: comment line`,
+		"data: {\"author\":\"agent_1\",\"content\":{\"parts\":[{\"text\":\"world\"}]}}\r",
+		`data: not json`,
+		`Error while running agent: boom`,
+		`data: {"author":"agent_1","turn_complete":true,"finish_reason":"STOP"}`,
+	}, "\n") + "\n"
+
+	events, text, err := CollectSSEEvents(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("CollectSSEEvents: %v", err)
+	}
+	if text != "hello world" {
+		t.Fatalf("text = %q", text)
+	}
+	var kinds []SSEEventType
+	for _, e := range events {
+		kinds = append(kinds, e.Type)
+	}
+	want := []SSEEventType{SSEEventText, SSEEventText, SSEEventError, SSEEventUnknown}
+	if len(kinds) != len(want) {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("kinds = %v, want %v", kinds, want)
+		}
+	}
+	if events[2].ErrorMessage != "boom" {
+		t.Fatalf("ADK error frame lost: %+v", events[2])
+	}
+}


### PR DESCRIPTION
Fixes #45.

One large tool response (a wide resource listing, a long log window) made the SSE parser fail with `bufio.Scanner: token too long` and drop the whole stream, later events included: Telegram, Discord, Slack and webhook users got "I couldn't generate a response" and the conversation was stuck.

- **The parser now grows with the line.** The fixed 1MB-per-line scanner is replaced with a dynamically growing reader, bounded only by process memory. No new static cap: any ceiling is just the next report waiting to happen, and the producer is Magec's own engine on localhost.
- **Streams that close without a final newline keep their last event.**

Diagnosis, proposed fix and test plan came from @dfradehubs in the issue: implemented as proposed. Thank you for the excellent report.