### PR TITLE
Landing page redesign: scroll-driven feature tour

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -30,284 +30,470 @@ title: "Magec: Self-hosted Multi-Agent AI Platform"
       </div>
     </div>
   </div>
+  <a href="#agents" class="scene__hint hero__hint" aria-label="Start the tour">
+    <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg0" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg0)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+  </a>
 </section>
 
-<!-- HOW IT WORKS -->
-<section id="how-it-works">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">How it works</span>
-      <h2 class="section-title">Three steps to AI automation</h2>
+<!-- SCENE: AGENTS -->
+<section id="agents" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-agent">Agents</span>
+      <h2 class="scene__title">One agent, everything it needs</h2>
+      <p class="scene__desc">Pick its brain. Plug in tools, skills and memory. Each agent is an independent unit, assembled in minutes.</p>
     </div>
-    <div class="steps stagger-children">
-      <div class="step">
-        <div class="step__number">1</div>
-        <div class="step__icon step__icon--sol">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/></svg>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path class="ec-backend" data-wire="0.10,0.24" d="M 285 122 C 345 122, 345 238, 394 238"/>
+          <path class="ec-mcp" data-wire="0.26,0.40" d="M 285 272 C 340 272, 345 270, 394 270"/>
+          <path class="ec-skill" data-wire="0.42,0.56" d="M 285 422 C 345 422, 345 302, 394 302"/>
+          <path class="ec-memory" data-wire="0.58,0.72" d="M 778 197 C 725 197, 715 246, 652 246"/>
+          <path class="ec-extra" data-wire="0.74,0.88" d="M 778 357 C 725 357, 715 286, 652 286"/>
+        </svg>
+        <div class="scene__end ec-backend" style="left:120px; top:92px" data-step="0.08">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="5" y="5" width="14" height="14" rx="2"/><rect x="10" y="10" width="4" height="4"/><line x1="9" y1="2" x2="9" y2="5"/><line x1="15" y1="2" x2="15" y2="5"/><line x1="9" y1="19" x2="9" y2="22"/><line x1="15" y1="19" x2="15" y2="22"/><line x1="2" y1="9" x2="5" y2="9"/><line x1="2" y1="15" x2="5" y2="15"/><line x1="19" y1="9" x2="22" y2="9"/><line x1="19" y1="15" x2="22" y2="15"/></svg>
+          <span class="scene__tag">all AI models</span>
         </div>
-        <h3 class="step__title">Create agents</h3>
-        <p class="step__desc">Give each agent its own LLM, personality, memory, voice and tools. Mix OpenAI, Anthropic, Gemini or Ollama, even in the same setup.</p>
-      </div>
-      <div class="step__connector"><svg viewBox="0 0 40 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".3"><path d="M0 12h32m0 0l-6-6m6 6l-6 6"/></svg></div>
-      <div class="step">
-        <div class="step__number">2</div>
-        <div class="step__icon step__icon--pink">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/><line x1="4" y1="4" x2="9" y2="9"/></svg>
+        <div class="scene__end ec-mcp" style="left:120px; top:242px" data-step="0.24">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="9" y1="2" x2="9" y2="8"/><line x1="15" y1="2" x2="15" y2="8"/><path d="M6 8h12v4a6 6 0 0 1-6 6 6 6 0 0 1-6-6z"/><line x1="12" y1="18" x2="12" y2="22"/></svg>
+          <span class="scene__tag">mcps</span>
         </div>
-        <h3 class="step__title">Chain into flows</h3>
-        <p class="step__desc">Build multi-agent workflows in a visual editor. Fan out in parallel, route on conditions, loop until the work is good. One agent writes, another reviews, another fact-checks.</p>
-      </div>
-      <div class="step__connector"><svg viewBox="0 0 40 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".3"><path d="M0 12h32m0 0l-6-6m6 6l-6 6"/></svg></div>
-      <div class="step">
-        <div class="step__number">3</div>
-        <div class="step__icon step__icon--atlantico">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        <div class="scene__end ec-skill" style="left:120px; top:392px" data-step="0.40">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+          <span class="scene__tag">skills</span>
         </div>
-        <h3 class="step__title">Connect everywhere</h3>
-        <p class="step__desc">Expose any agent or flow through voice, Telegram, webhooks or cron. Each client gets its own token and permissions. Add as many as you need.</p>
+        <div class="scene__end ec-memory" style="left:760px; top:167px" data-step="0.56">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0 0 18 0V5"/><path d="M3 12a9 3 0 0 0 18 0"/></svg>
+          <span class="scene__tag">semantic memory</span>
+        </div>
+        <div class="scene__end ec-extra" style="left:760px; top:327px" data-step="0.72">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span class="scene__tag">and more</span>
+        </div>
+        <div class="fnode fnode--agent" style="left:400px; top:210px;" data-step="0">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+            <span class="fnode__label">AGENT</span>
+            <span class="fnode__id">writer_1</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__skel" style="width:85%"></div>
+            <div class="fnode__skel" style="width:65%"></div>
+            <div class="fnode__skel" style="width:74%"></div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:22px"></span>
+          <span class="fnode__port" style="left:-6px; top:54px"></span>
+          <span class="fnode__port" style="left:-6px; top:86px"></span>
+          <span class="fnode__port" style="right:-6px; top:30px"></span>
+          <span class="fnode__port" style="right:-6px; top:70px"></span>
+        </div>
       </div>
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg1" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg1)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
   </div>
 </section>
 
-<!-- PILLARS -->
-<section id="what">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">The platform</span>
-      <h2 class="section-title">Everything you need to run AI agents</h2>
-      <p class="section-desc">Magec is a complete platform, not just an API wrapper. Agents, workflows, tools, memory, voice and integrations, managed from a single admin panel.</p>
+<!-- SCENE: TOOLS AND SKILLS -->
+<section id="tools" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-mcp">MCPs &amp; Skills</span>
+      <h2 class="scene__title">Real tools, learned know-how</h2>
+      <p class="scene__desc">Through MCP your agents operate real systems. Skills are playbooks they load to do the job the way you want.</p>
     </div>
-    <div class="pillars stagger-children">
-      <div class="pillar">
-        <div class="pillar__icon pillar__icon--sol">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-mcp" class="ec-mcp" data-wire="0.10,0.24" d="M 334 240 C 490 240, 540 160, 696 160"/>
+          <path id="w-skill" class="ec-skill" data-wire="0.58,0.72" d="M 334 280 C 490 280, 540 420, 696 420"/>
+        </svg>
+        <div class="fnode fnode--agent" style="left:90px; top:210px;" data-step="0">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+            <span class="fnode__label">AGENT</span>
+            <span class="fnode__id">writer_1</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__skel" style="width:85%"></div>
+            <div class="fnode__skel" style="width:65%"></div>
+          </div>
+          <span class="fnode__port" style="right:-6px; top:24px"></span>
+          <span class="fnode__port" style="right:-6px; top:64px"></span>
         </div>
-        <h3 class="pillar__title">Multi-Agent System</h3>
-        <p class="pillar__desc">Each agent is an independent unit with its own LLM, system prompt, tools and memory. Hot-reload from the admin: no restarts, no config files.</p>
-        <ul class="pillar__list">
-          <li>Per-agent LLM selection (GPT, Claude, Gemini, Ollama)</li>
-          <li>Hundreds of tools via MCP (Model Context Protocol)</li>
-          <li>Session + long-term semantic memory</li>
-        </ul>
-      </div>
-      <div class="pillar">
-        <div class="pillar__icon pillar__icon--pink">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        <div class="fnode fnode--mcp" style="left:700px; top:100px;" data-step="0.06">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="9" y1="2" x2="9" y2="8"/><line x1="15" y1="2" x2="15" y2="8"/><path d="M6 8h12v4a6 6 0 0 1-6 6 6 6 0 0 1-6-6z"/><line x1="12" y1="18" x2="12" y2="22"/></svg></div>
+            <span class="fnode__label">MCP</span>
+            <span class="fnode__id">home_assistant</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__line" data-step="0.28">turn_on_lights</div>
+            <div class="fnode__line" data-step="0.34">set_temperature</div>
+            <div class="fnode__line" data-step="0.40">snapshot_camera <em>+38</em></div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:54px"></span>
         </div>
-        <h3 class="pillar__title">Agentic Flows</h3>
-        <p class="pillar__desc">Chain agents into teams that work together. Build pipelines of 2 agents or 20 in a visual graph editor.</p>
-        <ul class="pillar__list">
-          <li>Parallel branches, condition routing, loops</li>
-          <li>Deterministic blocks that cost no tokens</li>
-          <li>Every run recorded and inspectable</li>
-        </ul>
-      </div>
-      <div class="pillar">
-        <div class="pillar__icon pillar__icon--atlantico">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+        <div class="fnode fnode--skill" style="left:700px; top:360px;" data-step="0.54">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></div>
+            <span class="fnode__label">SKILL</span>
+            <span class="fnode__id">daily_report</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__line" data-step="0.74">1. gather metrics</div>
+            <div class="fnode__line" data-step="0.79">2. compare trends</div>
+            <div class="fnode__line" data-step="0.84">3. draft summary</div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:54px"></span>
         </div>
-        <h3 class="pillar__title">Voice First</h3>
-        <p class="pillar__desc">Wake word detection, speech-to-text, text-to-speech, all server-side via ONNX Runtime. Each agent can have its own voice.</p>
-        <ul class="pillar__list">
-          <li>Privacy-first: audio never leaves your server</li>
-          <li>PWA installable on tablets and phones</li>
-          <li>"Oye Magec" hands-free activation</li>
-        </ul>
+        <span class="scene__pulse ec-mcp" data-travel="w-mcp,0.42,0.52"></span>
+        <span class="scene__pulse ec-skill" data-travel="w-skill,0.86,0.96"></span>
       </div>
-      <div class="pillar">
-        <div class="pillar__icon pillar__icon--green">
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg2" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg2)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+  </div>
+</section>
+
+<!-- SCENE: MEMORY -->
+<section id="memory" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-memory">Memory</span>
+      <h2 class="scene__title">It learns you</h2>
+      <p class="scene__desc">Things you mention in passing become long-term facts. Months later, your agents still remember, and it shows.</p>
+    </div>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-m1" class="ec-memory" data-wire="0.10,0.20" d="M 320 112 C 380 112, 380 240, 424 240"/>
+          <path id="w-m2" class="ec-memory" data-wire="0.26,0.36" d="M 320 268 C 380 268, 380 268, 424 268"/>
+          <path id="w-m3" class="ec-memory" data-wire="0.42,0.52" d="M 320 422 C 380 422, 380 296, 424 296"/>
+          <path id="w-m4" class="ec-memory" data-wire="0.62,0.72" d="M 674 268 C 720 268, 720 250, 764 250"/>
+        </svg>
+        <div class="mem-quote" style="left:70px; top:80px" data-step="0.06">
+          <em>march</em>
+          "I'm vegetarian"
+        </div>
+        <div class="mem-quote" style="left:70px; top:236px" data-step="0.22">
+          <em>april</em>
+          "my partner is Ana"
+        </div>
+        <div class="mem-quote" style="left:70px; top:390px" data-step="0.38">
+          <em>may</em>
+          "we moved to Tenerife"
+        </div>
+        <div class="fnode fnode--memory" style="left:430px; top:210px;" data-step="0">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0 0 18 0V5"/><path d="M3 12a9 3 0 0 0 18 0"/></svg></div>
+            <span class="fnode__label">MEMORY</span>
+            <span class="fnode__id">facts</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__line" data-step="0.20">diet: vegetarian</div>
+            <div class="fnode__line" data-step="0.36">partner: Ana</div>
+            <div class="fnode__line" data-step="0.52">home: Tenerife</div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:30px"></span>
+          <span class="fnode__port" style="left:-6px; top:58px"></span>
+          <span class="fnode__port" style="left:-6px; top:86px"></span>
+          <span class="fnode__port" style="right:-6px; top:58px"></span>
+        </div>
+        <div class="mem-quote" style="left:770px; top:180px; width:250px" data-step="0.58">
+          <em>june</em>
+          "book us a dinner saturday"
+        </div>
+        <div class="mem-quote" style="left:770px; top:290px; width:250px" data-step="0.76">
+          <em>the agent, without asking</em>
+          table for two, <mark>veggie</mark> tasting menu, <mark>Santa Cruz de Tenerife</mark>
+        </div>
+        <span class="scene__pulse ec-memory" data-travel="w-m4,0.68,0.76"></span>
+      </div>
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg8" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg8)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+  </div>
+</section>
+
+<!-- SCENE: FLOWS -->
+<section id="flows" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-flow">Flows</span>
+      <h2 class="scene__title">Chain agents into teams</h2>
+      <p class="scene__desc">Draw the pipeline on a canvas: parallel branches, condition routing, loops. One agent writes, another decides, code does the plumbing.</p>
+    </div>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-f1" class="ec-flow" data-wire="0.06,0.16" d="M 76 274 L 84 274"/>
+          <path id="w-f2" class="ec-flow" data-wire="0.22,0.34" d="M 334 274 C 385 274, 380 274, 424 274"/>
+          <path id="w-f3" class="ec-flow" data-wire="0.40,0.52" d="M 674 250 C 730 250, 715 164, 764 164"/>
+          <path id="w-f4" class="ec-flow" data-wire="0.54,0.66" d="M 674 298 C 730 298, 715 424, 764 424"/>
+          <path class="ec-flow wire-loop" data-step="0.72" d="M 550 336 C 550 470, 210 470, 210 336"/>
+        </svg>
+        <div class="scene__start" style="left:-14px; top:254px" data-step="0.02">
+          <div class="scene__start-card">
+            <span class="scene__start-ic"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg></span>
+            <span class="scene__start-label">Start</span>
+          </div>
+          <span class="scene__start-port"></span>
+        </div>
+        <div class="fnode fnode--agent" style="left:90px; top:220px;" data-step="0.16">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+            <span class="fnode__label">AGENT</span>
+            <span class="fnode__id">researcher</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__skel" style="width:80%"></div>
+            <div class="fnode__skel" style="width:60%"></div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:48px"></span>
+          <span class="fnode__port" style="right:-6px; top:48px"></span>
+        </div>
+        <div class="fnode fnode--router" style="left:430px; top:220px;" data-step="0.34">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/><line x1="4" y1="4" x2="9" y2="9"/></svg></div>
+            <span class="fnode__label">ROUTER</span>
+            <span class="fnode__id">quality_gate</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__line">pass: publisher</div>
+            <div class="fnode__line">fix: format_md</div>
+            <div class="fnode__line">retry: researcher</div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:48px"></span>
+          <span class="fnode__port" style="right:-6px; top:26px"></span>
+          <span class="fnode__port" style="right:-6px; top:74px"></span>
+        </div>
+        <div class="fnode fnode--agent" style="left:770px; top:110px;" data-step="0.52">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+            <span class="fnode__label">AGENT</span>
+            <span class="fnode__id">publisher</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__skel" style="width:75%"></div>
+            <div class="fnode__skel" style="width:55%"></div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:48px"></span>
+        </div>
+        <div class="fnode fnode--code" style="left:770px; top:360px; width:280px;" data-step="0.66">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div>
+            <span class="fnode__label">CODE</span>
+            <span class="fnode__id">format_md</span>
+          </div>
+          <div class="fnode__code"><span class="tk-c"># deterministic step: no tokens</span>
+best = <span class="tk-b">sorted</span>(drafts, key=score)[-1]
+out = <span class="tk-b">render</span>(best, format=<span class="tk-b">"md"</span>)</div>
+          <span class="fnode__port" style="left:-6px; top:48px"></span>
+        </div>
+        <span class="scene__pulse ec-flow" data-travel="w-f2,0.78,0.88"></span>
+      </div>
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg3" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg3)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+  </div>
+</section>
+
+<!-- SCENE: CLIENTS -->
+<section id="clients-scene" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-client">Clients</span>
+      <h2 class="scene__title">Anything can wake them</h2>
+      <p class="scene__desc">Voice, Telegram, webhooks, cron, plain HTTP, even other agents over A2A. Every client has its own token and reaches only the agents and flows you allow.</p>
+    </div>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-c1" class="ec-client" data-wire="0.07,0.17" d="M 260 102 C 480 102, 540 246, 696 246"/>
+          <path id="w-c2" class="ec-client" data-wire="0.21,0.31" d="M 260 198 C 480 198, 500 264, 696 264"/>
+          <path id="w-c3" class="ec-trigger" data-wire="0.35,0.45" d="M 260 294 C 480 294, 500 282, 696 282"/>
+          <path id="w-c4" class="ec-trigger" data-wire="0.49,0.59" d="M 260 390 C 480 390, 500 300, 696 300"/>
+          <path id="w-c5" class="ec-agent" data-wire="0.63,0.73" d="M 260 486 C 480 486, 540 318, 696 318"/>
+        </svg>
+        <div class="scene__end ec-client" style="left:100px; top:72px" data-step="0.05">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/></svg>
+          <span class="scene__tag">"Oye Magec"</span>
+        </div>
+        <div class="scene__end ec-client" style="left:100px; top:168px" data-step="0.19">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+          <span class="scene__tag">telegram, slack, discord</span>
+        </div>
+        <div class="scene__end ec-trigger" style="left:100px; top:264px" data-step="0.33">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          <span class="scene__tag">POST /webhook/alert</span>
         </div>
-        <h3 class="pillar__title">Automations</h3>
-        <p class="pillar__desc">Agents don't need a human to start working. Schedule them with cron, trigger them from webhooks, or chain them with external systems.</p>
-        <ul class="pillar__list">
-          <li>Cron jobs with standard syntax + @daily shorthands</li>
-          <li>Webhooks with passthrough or fixed commands</li>
-          <li>Full REST API with Swagger docs</li>
-        </ul>
+        <div class="scene__end ec-trigger" style="left:100px; top:360px" data-step="0.47">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15.5 14"/></svg>
+          <span class="scene__tag">cron 0 7 * * *</span>
+        </div>
+        <div class="scene__end ec-agent" style="left:100px; top:456px" data-step="0.61">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="6" cy="7" r="3.5"/><circle cx="18" cy="17" r="3.5"/><path d="M9.5 7h5a3 3 0 0 1 3 3v3.5"/><path d="M14.5 17h-5a3 3 0 0 1-3-3V10.5"/></svg>
+          <span class="scene__tag">other agents (a2a)</span>
+        </div>
+        <div class="fnode fnode--flow" style="left:700px; top:220px;" data-step="0">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="3"/><circle cx="19" cy="18" r="3"/><path d="M8 6h8a3 3 0 0 1 3 3v6"/></svg></div>
+            <span class="fnode__label">FLOW</span>
+            <span class="fnode__id">morning_brief</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__skel" style="width:82%"></div>
+            <div class="fnode__skel" style="width:64%"></div>
+            <div class="fnode__skel" style="width:72%"></div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:26px"></span>
+          <span class="fnode__port" style="left:-6px; top:44px"></span>
+          <span class="fnode__port" style="left:-6px; top:62px"></span>
+          <span class="fnode__port" style="left:-6px; top:80px"></span>
+          <span class="fnode__port" style="left:-6px; top:98px"></span>
+        </div>
+        <span class="scene__pulse ec-client" data-travel="w-c1,0.77,0.87"></span>
+        <span class="scene__pulse ec-agent" data-travel="w-c5,0.83,0.93"></span>
       </div>
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg4" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg4)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
   </div>
 </section>
 
-<!-- USE CASES -->
-<section id="use-cases">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">What you can build</span>
-      <h2 class="section-title">Real examples, not buzzwords</h2>
+<!-- SCENE: VOICE -->
+<section id="voice" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-client">Voice</span>
+      <h2 class="scene__title">Talk to it like a person</h2>
+      <p class="scene__desc">Wake it with your voice and just talk, like Alexa, if Alexa were actually smart and knew you.</p>
     </div>
-    <div class="features-grid stagger-children">
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--sol">🏠</div>
-        <h3 class="feature-card__title">Smart home with natural language</h3>
-        <p class="feature-card__desc">Connect Home Assistant via MCP. Ask "turn off the living room lights" from your voice tablet, Telegram, or a cron job that dims everything at midnight.</p>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-v1" class="ec-client" style="stroke-width:2" data-wire="0.06,0.24" d="M 60 270 Q 74 210, 88 270 Q 102 330, 116 270 Q 130 180, 144 270 Q 158 350, 172 270 Q 186 225, 200 270 Q 214 315, 228 270 Q 242 245, 256 270"/>
+          <path id="w-v2" class="ec-client" data-wire="0.28,0.38" d="M 256 270 L 394 270"/>
+          <path id="w-v3" class="ec-agent" data-wire="0.52,0.62" d="M 646 270 L 782 270"/>
+          <path id="w-v4" class="ec-agent" style="stroke-width:2" data-wire="0.66,0.86" d="M 782 270 Q 796 210, 810 270 Q 824 335, 838 270 Q 852 175, 866 270 Q 880 355, 894 270 Q 908 220, 922 270 Q 936 320, 950 270 Q 964 248, 978 270"/>
+        </svg>
+        <div class="scene__end ec-client" style="left:80px; top:330px" data-step="0.04">
+          <span class="scene__tag">"Oye Magec, dim the lights"</span>
+        </div>
+        <div class="fnode fnode--agent" style="left:400px; top:210px;" data-step="0.38">
+          <div class="fnode__head">
+            <div class="fnode__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+            <span class="fnode__label">AGENT</span>
+            <span class="fnode__id">home_butler</span>
+          </div>
+          <div class="fnode__body">
+            <div class="fnode__line" data-step="0.44"><em>stt:</em> dim the lights</div>
+            <div class="fnode__line" data-step="0.48"><em>mcp:</em> lights.dim(30%)</div>
+            <div class="fnode__line" data-step="0.52"><em>tts:</em> "done"</div>
+          </div>
+          <span class="fnode__port" style="left:-6px; top:54px"></span>
+          <span class="fnode__port" style="right:-6px; top:54px"></span>
+        </div>
+        <div class="scene__end ec-agent" style="left:800px; top:330px" data-step="0.80">
+          <span class="scene__tag">"Done. Anything else?"</span>
+        </div>
+        <span class="scene__pulse ec-client" data-travel="w-v2,0.40,0.48"></span>
+        <span class="scene__pulse ec-agent" data-travel="w-v3,0.56,0.64"></span>
       </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--pink">🏗</div>
-        <h3 class="feature-card__title">Software factory</h3>
-        <p class="feature-card__desc">13 agents in a pipeline: product manager → architect → developers → QA → documentation. Feed it a feature request, get back a complete technical spec with code.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--atlantico">🎙</div>
-        <h3 class="feature-card__title">Multi-agent platform for your business</h3>
-        <p class="feature-card__desc">Put a tablet at the front desk. Staff speaks, the agent listens, checks inventory via MCP, and answers hands-free. Each agent has its own voice.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--green">📊</div>
-        <h3 class="feature-card__title">Automated reports</h3>
-        <p class="feature-card__desc">A cron job fires every morning. An agent queries your database, another writes the summary, a third formats it. The result lands in your inbox via webhook.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--lava">🔬</div>
-        <h3 class="feature-card__title">Research pipeline</h3>
-        <p class="feature-card__desc">Two researchers work in parallel, a critic reviews their output, a fact-checker verifies claims, a synthesizer produces the final report. All from a single prompt.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--purple">🔌</div>
-        <h3 class="feature-card__title">Whatever you connect</h3>
-        <p class="feature-card__desc">MCP gives your agents access to hundreds of tools: GitHub, databases, file systems, APIs. The more tools you connect, the more your agents can do.</p>
-      </div>
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg5" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg5)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
   </div>
 </section>
 
-<!-- FEATURES -->
-<section id="features">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">Under the hood</span>
-      <h2 class="section-title">What powers it</h2>
+<!-- SCENE: SECRETS -->
+<section id="secrets" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label ec-secret">Secrets</span>
+      <h2 class="scene__title">Models never see your keys</h2>
+      <p class="scene__desc">Secrets live encrypted at rest and are swapped in only at call time. The model works with placeholders; your tools get the real value.</p>
     </div>
-    <div class="features-grid stagger-children">
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--sol">✦</div>
-        <h3 class="feature-card__title">Agents</h3>
-        <p class="feature-card__desc">Each agent has its own LLM, system prompt, memory, voice, and tools. Create as many as you need. Changes take effect instantly, no restarts.</p>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-s1" class="ec-secret" data-wire="0.20,0.70" d="M 520 96 L 520 440"/>
+        </svg>
+        <div class="sec-col" style="left:395px; top:20px; width:250px" data-step="0.08">
+          <span class="sec-value sec-value--masked">{{secret:API_KEY}}</span>
+          <span class="sec-caption">what the model sees</span>
+        </div>
+        <span class="sec-ball" style="left:507px; top:252px" data-step="0.42"></span>
+        <div class="sec-col" style="left:395px; top:452px; width:250px" data-step="0.68">
+          <span class="sec-value sec-value--real">sk-live-4f8a91c2</span>
+          <span class="sec-caption">what your tools get</span>
+        </div>
+        <div class="sec-rest" style="left:110px; top:180px" data-step="0.30">
+          <span>gAAAAABmJx9v3q</span><br>
+          <span>Zk1uYzR0aXlXcU</span><br>
+          <span>x2b3JQZXJhbmRv</span><br>
+          <span class="sec-caption">at rest: encrypted</span>
+        </div>
+        <span class="scene__pulse ec-secret" data-travel="w-s1,0.74,0.90"></span>
       </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--pink">⛓</div>
-        <h3 class="feature-card__title">Flows</h3>
-        <p class="feature-card__desc">Chain agents into workflows on a visual canvas. Parallel branches, condition routing, loops, flows inside flows. Deterministic blocks handle the plumbing so you spend tokens only where thinking happens.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--purple">⚡</div>
-        <h3 class="feature-card__title">AI Backends</h3>
-        <p class="feature-card__desc">OpenAI, Anthropic, Google Gemini, Ollama. Mix cloud and local models. One agent can use GPT-4, another a local Qwen, in the same flow.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--green">🔧</div>
-        <h3 class="feature-card__title">MCP Tools</h3>
-        <p class="feature-card__desc">Connect external tools via Model Context Protocol. Home Assistant, GitHub, databases, file systems: hundreds of integrations, growing every day.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--atlantico">🧠</div>
-        <h3 class="feature-card__title">Memory</h3>
-        <p class="feature-card__desc">Session memory keeps conversation history in Redis. Long-term memory stores facts about you in PostgreSQL with semantic search. Your agents remember.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-card__icon feature-card__icon--lava">🎙</div>
-        <h3 class="feature-card__title">Voice</h3>
-        <p class="feature-card__desc">Wake word detection, voice activity detection, speech-to-text, text-to-speech. All processed server-side via ONNX Runtime. Each agent can have its own voice.</p>
-      </div>
+    </div>
+    <div class="scene__hint">
+      <svg class="scene__hint-ball" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="hintg6" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs><circle cx="32" cy="32" r="26" fill="url(#hintg6)"/><circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="26" cy="18" r="1.5" fill="white" opacity=".7"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/><circle cx="38" cy="38" r="2" fill="white" opacity=".75"/><circle cx="24" cy="40" r="1.4" fill="white" opacity=".65"/></svg>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
     </div>
   </div>
 </section>
 
-<!-- ARCHITECTURE -->
-<section id="architecture" class="architecture">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">Architecture</span>
-      <h2 class="section-title">How it all connects</h2>
-      <p class="section-desc">Clients on the left, AI backends on the right, Magec orchestrating in the middle. Every connection is configurable.</p>
+<!-- SCENE: RUNS -->
+<section id="runs" class="scene" data-scene>
+  <div class="scene__sticky">
+    <div class="scene__head" data-step="0">
+      <span class="scene__label" style="color:#2dd4bf">Runs</span>
+      <h2 class="scene__title">Every run, recorded</h2>
+      <p class="scene__desc">Each step, each decision, each failure: timestamped and inspectable from the admin panel.</p>
     </div>
-    <div class="reveal">
-      <img src="img/architecture.svg" alt="Magec Architecture" class="architecture__img">
-    </div>
-  </div>
-</section>
-
-<!-- SCREENSHOTS -->
-<section id="screenshots">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">Admin Panel</span>
-      <h2 class="section-title">Manage everything visually</h2>
-      <p class="section-desc">No config files to edit. Create agents, design flows, connect tools, manage clients, all from your browser.</p>
-    </div>
-    <div class="screenshots reveal">
-      <img src="img/screenshots/admin-agents.png" alt="Admin UI: Agents" class="screenshot screenshot--desktop">
-      <img src="img/screenshots/admin-flow-editor.png" alt="Admin UI: Flow editor" class="screenshot screenshot--desktop screenshot--crop">
-    </div>
-    <div class="screenshots reveal" style="margin-top: 1rem;">
-      <img src="img/screenshots/admin-backends.png" alt="Admin UI: Backends" class="screenshot screenshot--desktop">
-      <img src="img/screenshots/admin-clients.png" alt="Admin UI: Clients" class="screenshot screenshot--desktop">
-    </div>
-    <div class="screenshots reveal" style="margin-top: 1rem;">
-      <img src="img/screenshots/admin-conversations.png" alt="Admin UI: Conversations" class="screenshot screenshot--desktop">
-      <img src="img/screenshots/admin-conversation-detail.png" alt="Admin UI: Conversation detail" class="screenshot screenshot--desktop">
-    </div>
-    <div class="section-header reveal" style="margin-top: 4rem;">
-      <span class="section-label">Voice Interface</span>
-      <h2 class="section-title">Talk to your agents</h2>
-      <p class="section-desc">Say "Oye Magec" or tap to talk. Switch between agents and flows. Choose who speaks when a team responds. Install it on your phone like a native app.</p>
-    </div>
-    <div class="screenshots reveal">
-      <img src="img/screenshots/voice-ui-home-idle.png" alt="Voice UI: Home" class="screenshot screenshot--phone">
-      <img src="img/screenshots/voice-ui-home-recording.png" alt="Voice UI: Recording" class="screenshot screenshot--phone">
-      <img src="img/screenshots/voice-ui-chat.png" alt="Voice UI: Chat" class="screenshot screenshot--phone">
-      <img src="img/screenshots/voice-ui-settings.png" alt="Voice UI: Settings" class="screenshot screenshot--phone">
-    </div>
-  </div>
-</section>
-
-<!-- CLIENTS -->
-<section id="clients">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">Clients</span>
-      <h2 class="section-title">Reach your agents from anywhere</h2>
-      <p class="section-desc">Every client gets its own token, its own set of allowed agents, and its own way of connecting. Add as many as you need.</p>
-    </div>
-    <div class="clients-grid stagger-children">
-      <div class="client-card"><div><div class="client-card__name">Voice UI</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Browser-based voice interface with wake word, push-to-talk, agent switching, conversation history. Installable as PWA.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">Admin UI</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Visual management panel. Create agents, design flows, connect tools, manage clients. Keyboard shortcuts, search palette, live health checks.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">Telegram</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Text or voice messages. Multiple response modes (text, voice, mirror, both). Per-chat agent switching.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">Webhooks</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">HTTP endpoints for external integrations. Fixed command or passthrough mode. Wire them to CI, forms, alerts, or any system.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">Cron</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Scheduled tasks. Daily summaries, periodic checks, automated maintenance. Standard cron syntax plus shorthands like @daily.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">REST API</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Full API with Swagger docs on both ports. Build any custom integration you can imagine.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">Slack</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Socket Mode, no public URL needed. DMs and @mentions in channels. Per-channel agent switching.</p></div></div>
-      <div class="client-card"><div><div class="client-card__name">Discord</div><div class="client-card__status client-card__status--ready">✓ Available</div><p class="client-card__desc">Gateway WebSocket, no public URL needed. DMs, @mentions, voice messages, reactions, and commands.</p></div></div>
-    </div>
-  </div>
-</section>
-
-<!-- PROVIDERS -->
-<section id="providers">
-  <div class="container">
-    <div class="section-header reveal">
-      <span class="section-label">AI Backends</span>
-      <h2 class="section-title">Bring any model</h2>
-      <p class="section-desc">Each agent picks its own backend. Mix a cloud model for complex reasoning with a local model for fast tasks, in the same flow.</p>
-    </div>
-    <div class="providers-grid stagger-children">
-      <div class="provider-card"><div class="provider-card__name">OpenAI</div><div class="provider-card__type">Cloud</div></div>
-      <div class="provider-card"><div class="provider-card__name">Anthropic</div><div class="provider-card__type">Cloud</div></div>
-      <div class="provider-card"><div class="provider-card__name">Google Gemini</div><div class="provider-card__type">Cloud</div></div>
-      <div class="provider-card"><div class="provider-card__name">Ollama</div><div class="provider-card__type">Local</div></div>
-    </div>
-  </div>
-</section>
-
-<!-- ABOUT -->
-<section id="about">
-  <div class="container container--narrow">
-    <div class="section-header reveal">
-      <span class="section-label">About</span>
-      <h2 class="section-title">Why "Magec"?</h2>
-      <p class="section-desc"><strong>Magec</strong> (/maˈxek/) was the god of the Sun worshipped by the Guanches, the aboriginal Berber inhabitants of Tenerife in the Canary Islands. The name honors this Canarian heritage while reflecting the project's purpose: to illuminate and assist.</p>
+    <div class="scene__fit">
+      <div class="scene__stage">
+        <svg class="scene__wires" viewBox="0 0 1040 560" aria-hidden="true">
+          <path id="w-r1" style="color:var(--piedra-600)" data-wire="0.06,0.80" d="M 370 60 L 370 500"/>
+        </svg>
+        <span class="run-dot run-dot--ok" style="left:364px; top:94px" data-step="0.16"></span>
+        <div class="run-row" style="left:410px; top:88px" data-step="0.16">
+          <span class="run-row__name">researcher</span><span class="run-row__meta">2.1s</span>
+        </div>
+        <span class="run-dot run-dot--ok" style="left:364px; top:194px" data-step="0.32"></span>
+        <div class="run-row" style="left:410px; top:188px" data-step="0.32">
+          <span class="run-row__name">quality_gate</span><span class="run-row__meta">0.1s</span>
+        </div>
+        <span class="run-dot run-dot--ok" style="left:364px; top:294px" data-step="0.48"></span>
+        <div class="run-row" style="left:410px; top:288px" data-step="0.48">
+          <span class="run-row__name">format_md</span><span class="run-row__meta">0.2s</span>
+        </div>
+        <span class="run-dot run-dot--fail" style="left:364px; top:394px" data-step="0.64"></span>
+        <div class="run-row run-row--fail" style="left:410px; top:388px" data-step="0.64">
+          <span class="run-row__name">publisher</span><span class="run-row__meta">failed</span>
+        </div>
+        <span class="run-dot run-dot--ok" style="left:364px; top:494px" data-step="0.80"></span>
+        <div class="run-row" style="left:410px; top:488px" data-step="0.80">
+          <span class="run-row__name">publisher (retry)</span><span class="run-row__meta">1.4s</span>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -17,25 +17,58 @@ theme = 'magec'
 
 [menu]
   [[menu.main]]
-    name = 'How it works'
-    url = '/#how-it-works'
+    name = 'Home'
+    url = '/'
     weight = 1
   [[menu.main]]
-    name = 'Platform'
-    url = '/#what'
+    identifier = 'tour'
+    name = 'Tour'
+    url = '/#agents'
     weight = 2
   [[menu.main]]
-    name = 'Use cases'
-    url = '/#use-cases'
+    name = 'Agents'
+    parent = 'tour'
+    url = '/#agents'
+    weight = 1
+  [[menu.main]]
+    name = 'MCPs & Skills'
+    parent = 'tour'
+    url = '/#tools'
+    weight = 2
+  [[menu.main]]
+    name = 'Memory'
+    parent = 'tour'
+    url = '/#memory'
     weight = 3
   [[menu.main]]
-    name = 'Screenshots'
-    url = '/#screenshots'
+    name = 'Flows'
+    parent = 'tour'
+    url = '/#flows'
     weight = 4
+  [[menu.main]]
+    name = 'Clients'
+    parent = 'tour'
+    url = '/#clients-scene'
+    weight = 5
+  [[menu.main]]
+    name = 'Voice'
+    parent = 'tour'
+    url = '/#voice'
+    weight = 6
+  [[menu.main]]
+    name = 'Secrets'
+    parent = 'tour'
+    url = '/#secrets'
+    weight = 7
+  [[menu.main]]
+    name = 'Runs'
+    parent = 'tour'
+    url = '/#runs'
+    weight = 8
   [[menu.main]]
     name = 'Docs'
     url = '/docs/'
-    weight = 5
+    weight = 3
 
   # Docs sidebar menu
   [[menu.docs]]

--- a/website/themes/magec/layouts/partials/footer.html
+++ b/website/themes/magec/layouts/partials/footer.html
@@ -2,13 +2,16 @@
   <div class="container">
     <div class="footer__inner">
       <div class="footer__brand">
-        <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" width="20" height="20">
-          <defs><linearGradient id="fg" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs>
-          <circle cx="32" cy="32" r="26" fill="url(#fg)"/>
-          <circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/>
-          <circle cx="38" cy="38" r="2" fill="white" opacity=".75"/>
-        </svg>
-        Magec · Apache 2.0
+        <div class="footer__brand-line">
+          <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+            <defs><linearGradient id="fg" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#f87171"/></linearGradient></defs>
+            <circle cx="32" cy="32" r="26" fill="url(#fg)"/>
+            <circle cx="20" cy="24" r="2" fill="white" opacity=".9"/><circle cx="40" cy="22" r="1.8" fill="white" opacity=".8"/>
+            <circle cx="38" cy="38" r="2" fill="white" opacity=".75"/>
+          </svg>
+          Magec 2025
+        </div>
+        <div class="footer__tagline">Made with ❤️ from Canary Islands 🇮🇨</div>
       </div>
       <ul class="footer__links">
         <li><a href="{{ .Site.Params.github }}" target="_blank" rel="noopener">GitHub</a></li>

--- a/website/themes/magec/layouts/partials/nav.html
+++ b/website/themes/magec/layouts/partials/nav.html
@@ -15,7 +15,20 @@
     </button>
     <ul class="nav__links">
       {{ range .Site.Menus.main }}
+      {{ if .HasChildren }}
+      <li class="nav__dropdown">
+        <a href="{{ .URL }}" class="nav__link">{{ .Name }}
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+        </a>
+        <ul class="nav__dropdown-menu">
+          {{ range .Children }}
+          <li><a href="{{ .URL }}" class="nav__dropdown-link">{{ .Name }}</a></li>
+          {{ end }}
+        </ul>
+      </li>
+      {{ else }}
       <li><a href="{{ .URL }}" class="nav__link">{{ .Name }}</a></li>
+      {{ end }}
       {{ end }}
       <li>
         <a href="{{ .Site.Params.github }}" class="nav__cta" target="_blank" rel="noopener">

--- a/website/themes/magec/static/css/style.css
+++ b/website/themes/magec/static/css/style.css
@@ -113,6 +113,30 @@ img { max-width: 100%; height: auto; }
 .nav__link:hover { color: var(--arena-100); background: rgba(61,61,68,.3); }
 .nav__link--active { color: var(--sol-400); }
 
+/* Tour dropdown */
+.nav__dropdown { position: relative; }
+.nav__dropdown .nav__link { display: inline-flex; align-items: center; gap: .3rem; }
+.nav__dropdown .nav__link svg { width: 13px; height: 13px; opacity: .6; transition: transform .15s; }
+.nav__dropdown:hover .nav__link svg { transform: rotate(180deg); }
+.nav__dropdown-menu {
+  position: absolute; top: 100%; left: 0; min-width: 170px;
+  list-style: none; padding: .5rem; margin-top: .25rem;
+  background: rgba(18,18,20,.97); backdrop-filter: blur(12px);
+  border: 1px solid rgba(61,61,68,.4); border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,.4);
+  opacity: 0; visibility: hidden; transform: translateY(-4px);
+  transition: opacity .15s ease, transform .15s ease, visibility .15s;
+}
+.nav__dropdown:hover .nav__dropdown-menu,
+.nav__dropdown:focus-within .nav__dropdown-menu {
+  opacity: 1; visibility: visible; transform: translateY(0);
+}
+.nav__dropdown-link {
+  display: block; font-size: .8125rem; color: var(--arena-400);
+  padding: .45rem .75rem; border-radius: 8px; transition: color .15s, background .15s;
+}
+.nav__dropdown-link:hover { color: var(--arena-100); background: rgba(61,61,68,.3); }
+
 .nav__cta {
   display: inline-flex; align-items: center; gap: .25rem;
   background: var(--sol-500); color: var(--piedra-950);
@@ -136,6 +160,13 @@ img { max-width: 100%; height: auto; }
   .nav__link { padding: .75rem 1rem; width: 100%; }
   .nav__cta { margin: .5rem 0 0 0; justify-content: center; }
   .nav__toggle { display: block; }
+  .nav__dropdown { width: 100%; }
+  .nav__dropdown-menu {
+    position: static; opacity: 1; visibility: visible; transform: none;
+    background: none; border: none; box-shadow: none; backdrop-filter: none;
+    padding: 0 0 0 1rem; margin: 0;
+  }
+  .nav__dropdown .nav__link svg { display: none; }
 }
 
 /* ---------- HERO ---------- */
@@ -418,8 +449,10 @@ section { padding: 6rem 0; }
 
 .footer { border-top: 1px solid rgba(61,61,68,.3); padding: 2rem 0; }
 .footer__inner { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 1rem; }
-.footer__brand { display: flex; align-items: center; gap: .5rem; font-weight: 600; color: var(--arena-400); font-size: .875rem; }
+.footer__brand { display: flex; flex-direction: column; gap: .25rem; font-weight: 600; color: var(--arena-400); font-size: .875rem; }
+.footer__brand-line { display: flex; align-items: center; gap: .5rem; }
 .footer__brand svg { width: 20px; height: 20px; }
+.footer__tagline { font-weight: 400; font-size: .8125rem; color: var(--arena-500); }
 .footer__links { display: flex; gap: 1.5rem; list-style: none; }
 .footer__links a { color: var(--arena-500); font-size: .8125rem; transition: color .15s; }
 .footer__links a:hover { color: var(--arena-200); }
@@ -647,3 +680,277 @@ section { padding: 6rem 0; }
 .stagger-children.visible > *:nth-child(7) { transition-delay: .35s; }
 .stagger-children.visible > *:nth-child(8) { transition-delay: .4s; }
 .stagger-children.visible > * { opacity: 1; transform: translateY(0); }
+
+
+/* ---------- SCENES (scroll-driven feature stories) ---------- */
+
+.scene { position: relative; height: 260vh; padding: 0; }
+/* Cancel html's scroll-padding-top (nav offset) plus 2px: anchor jumps must
+   land with the sticky engaged (rect.top <= 1) so the autoplay clock starts. */
+.scene { scroll-margin-top: calc(-5rem - 2px); }
+.scene__sticky {
+  position: sticky; top: 0; height: 100vh;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  overflow: hidden;
+}
+
+.scene__head { text-align: center; max-width: 640px; padding: 0 1.5rem; margin-bottom: 2.5rem; }
+.scene__label {
+  display: inline-block; font-size: .75rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .1em; margin-bottom: .5rem;
+}
+.scene__title {
+  font-size: clamp(1.75rem, 4vw, 2.5rem); font-weight: 800;
+  letter-spacing: -.03em; line-height: 1.15; margin-bottom: .75rem;
+}
+.scene__desc { font-size: 1.0625rem; color: var(--arena-400); line-height: 1.7; }
+
+.scene__fit {
+  transform: scale(min(1, calc((100vw - 2rem) / 1040)));
+  transform-origin: top center;
+}
+.scene__stage { position: relative; width: 1040px; height: 560px; }
+
+.scene__wires { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
+.scene__wires path { fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; opacity: .55; }
+.scene__wires .wire-ghost { opacity: .12; stroke-dasharray: none !important; stroke-dashoffset: 0 !important; }
+.scene__wires path[data-step] { opacity: 0; transition: opacity .5s ease; transform: none; }
+.scene__wires path[data-step].on { opacity: .55; }
+
+/* Scroll-step reveals */
+[data-step] {
+  opacity: 0; transform: translateY(10px);
+  transition: opacity .5s cubic-bezier(.16,1,.3,1), transform .5s cubic-bezier(.16,1,.3,1);
+}
+[data-step].on { opacity: 1; transform: none; }
+
+/* Entity colors (see .agents/ENTITY_COLORS.md) */
+.ec-agent   { color: var(--sol-400); }
+.ec-backend { color: #c084fc; }
+.ec-mcp     { color: var(--atlantico-400); }
+.ec-skill   { color: #22d3ee; }
+.ec-memory  { color: #4ade80; }
+.ec-flow    { color: #fb7185; }
+.ec-client  { color: var(--lava-400); }
+.ec-secret  { color: var(--sol-500); }
+.ec-trigger { color: #2dd4bf; }
+.ec-extra   { color: var(--arena-500); }
+
+/* Wire endpoints: bare glyph + one short mono label. No boxes, no pills. */
+.scene__end {
+  position: absolute; width: 160px;
+  display: flex; flex-direction: column; align-items: center; gap: .35rem;
+}
+.scene__end svg { width: 30px; height: 30px; }
+.scene__tag {
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  font-size: .8125rem; line-height: 1.3; text-align: center;
+}
+
+/* Scroll hint: Magec ball bobbing, visible until the scene finishes drawing */
+.scene__hint {
+  position: absolute; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
+  display: flex; flex-direction: column; align-items: center; gap: .3rem;
+  color: var(--arena-400);
+  animation: hintPulse 2s ease-in-out infinite;
+  transition: opacity .5s ease;
+}
+.scene__hint-ball { width: 26px; height: 26px; animation: hintBob 1.2s ease-in-out infinite; }
+.scene__hint svg:not(.scene__hint-ball) { width: 18px; height: 18px; }
+/* Stays visible when the scene completes: it doubles as the next-scene button. */
+.scene__hint { cursor: pointer; }
+.scene__hint:hover { animation: none; opacity: 1; }
+.scene__hint:hover .scene__hint-ball { transform: scale(1.15); animation: none; transition: transform .15s; }
+/* Hero variant of the hint: anchor to the first scene, entrance-delayed */
+.hero__hint {
+  color: var(--arena-400);
+  animation: fadeIn .6s ease 1.2s both, hintPulse 2s ease-in-out 1.8s infinite;
+}
+@keyframes hintBob { 0%, 100% { transform: translateY(-2px); } 50% { transform: translateY(7px); } }
+@keyframes hintPulse { 0%, 100% { opacity: .6; } 50% { opacity: 1; } }
+
+/* Flow node card, cloned from the editor's design system */
+.fnode {
+  position: absolute; width: 240px; border-radius: 14px;
+  background: rgba(26,26,29,.95); border: 1px solid;
+  box-shadow: 0 10px 24px rgba(0,0,0,.45);
+  transition: border-color .6s ease, opacity .5s cubic-bezier(.16,1,.3,1), transform .5s cubic-bezier(.16,1,.3,1);
+}
+.fnode__head { display: flex; align-items: center; gap: 10px; padding: 10px 12px; border-radius: 14px 14px 0 0; }
+.fnode__icon {
+  width: 28px; height: 28px; border-radius: 8px;
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.fnode__icon svg { width: 17px; height: 17px; }
+.fnode__label { font-size: 12px; font-weight: 700; letter-spacing: .1em; }
+.fnode__id {
+  margin-left: auto; font-size: 11px; color: var(--arena-500);
+  background: rgba(42,42,47,.6); border-radius: 5px; padding: 2px 7px;
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+}
+.fnode__body { padding: 5px 12px 14px; }
+.fnode__skel { height: 8px; border-radius: 4px; background: var(--piedra-700); margin-top: 9px; }
+.fnode__port {
+  position: absolute; width: 11px; height: 11px; border-radius: 50%;
+  background: var(--piedra-600); border: 2px solid var(--piedra-950);
+}
+
+.fnode--agent { border-color: rgba(245,158,11,.3); }
+.fnode--agent .fnode__head { background: rgba(245,158,11,.06); }
+.fnode--agent .fnode__icon { background: rgba(245,158,11,.15); color: var(--sol-400); }
+.fnode--agent .fnode__label { color: var(--sol-400); }
+
+.fnode--mcp { border-color: rgba(8,145,178,.35); }
+.fnode--mcp .fnode__head { background: rgba(8,145,178,.08); }
+.fnode--mcp .fnode__icon { background: rgba(8,145,178,.18); color: var(--atlantico-400); }
+.fnode--mcp .fnode__label { color: var(--atlantico-400); }
+
+.fnode--skill { border-color: rgba(34,211,238,.3); }
+.fnode--skill .fnode__head { background: rgba(34,211,238,.06); }
+.fnode--skill .fnode__icon { background: rgba(34,211,238,.15); color: #22d3ee; }
+.fnode--skill .fnode__label { color: #22d3ee; }
+
+/* Mono content lines inside a node card */
+.fnode__line {
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  font-size: 12px; line-height: 1.4; color: var(--arena-300);
+  padding: 2.5px 0;
+}
+.fnode__line em { font-style: normal; color: var(--arena-600); }
+
+.fnode--memory { border-color: rgba(74,222,128,.3); }
+.fnode--memory .fnode__head { background: rgba(74,222,128,.06); }
+.fnode--memory .fnode__icon { background: rgba(74,222,128,.15); color: #4ade80; }
+.fnode--memory .fnode__label { color: #4ade80; }
+
+/* Memory scene: things you said, and the reply that remembers them */
+.mem-quote {
+  position: absolute; width: 240px;
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  font-size: .9375rem; line-height: 1.5; color: var(--arena-200);
+}
+.mem-quote em {
+  display: block; font-style: normal; font-family: system-ui, -apple-system, sans-serif;
+  font-size: .6875rem; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--arena-600); margin-bottom: .2rem;
+}
+.mem-quote mark { background: none; color: #4ade80; }
+
+/* A call travelling along a wire: bare dot, no glow circus */
+.scene__pulse {
+  position: absolute; top: -4.5px; left: -4.5px;
+  width: 9px; height: 9px; border-radius: 50%;
+  background: currentColor; opacity: 0;
+  transition: opacity .2s linear;
+}
+
+/* When the scene completes, the assembled agent lights up subtly */
+.scene--done .fnode--agent { border-color: rgba(245,158,11,.55); }
+
+
+/* Router / code / flow node variants (colors from the editor design system) */
+.fnode--router { border-color: rgba(8,145,178,.35); }
+.fnode--router .fnode__head { background: rgba(8,145,178,.08); }
+.fnode--router .fnode__icon { background: rgba(8,145,178,.18); color: var(--atlantico-400); }
+.fnode--router .fnode__label { color: var(--atlantico-400); }
+
+.fnode--code { border-color: rgba(16,185,129,.3); }
+.fnode--code .fnode__head { background: rgba(16,185,129,.06); }
+.fnode--code .fnode__icon { background: rgba(16,185,129,.15); color: #34d399; }
+.fnode--code .fnode__label { color: #34d399; }
+
+.fnode--flow { border-color: rgba(251,113,133,.3); }
+.fnode--flow .fnode__head { background: rgba(251,113,133,.06); }
+.fnode--flow .fnode__icon { background: rgba(251,113,133,.15); color: #fb7185; }
+.fnode--flow .fnode__label { color: #fb7185; }
+
+.fnode__code {
+  margin: 3px 12px 12px; padding: 8px 10px; border-radius: 9px;
+  background: var(--piedra-950); border: 1px solid var(--piedra-800);
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  font-size: 11px; line-height: 1.6; color: var(--arena-300); white-space: pre;
+}
+.fnode__code .tk-c { color: var(--arena-600); font-style: italic; }
+.fnode__code .tk-b { color: #6ee7b7; }
+
+/* Flow entry dot, cloned from the editor's Start dot */
+.scene__entry {
+  position: absolute; width: 17px; height: 17px; border-radius: 50%;
+  background: #f43f5e; border: 2px solid var(--piedra-900); z-index: 2;
+}
+
+/* Dashed wire (loops) */
+.wire-loop { stroke-dasharray: 6 7 !important; }
+.wire-loop-ghost { opacity: .12; }
+
+/* ---------- SECRETS SCENE ---------- */
+
+.sec-col {
+  position: absolute; display: flex; flex-direction: column; align-items: center;
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+}
+.sec-value { font-size: 1.35rem; letter-spacing: .01em; }
+.sec-value--masked { color: var(--arena-400); }
+.sec-value--real {
+  background: linear-gradient(135deg, var(--sol-400), var(--lava-500));
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+}
+.sec-caption {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: .8125rem; color: var(--arena-500); margin-top: .4rem;
+}
+.sec-ball {
+  position: absolute; width: 26px; height: 26px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--sol-400), var(--lava-500));
+  border: 3px solid var(--piedra-950); z-index: 2;
+}
+.sec-rest {
+  position: absolute; text-align: left;
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+  font-size: .8125rem; line-height: 1.8; color: var(--piedra-600);
+  user-select: none;
+}
+.sec-rest .sec-caption { text-align: center; }
+
+/* ---------- RUNS / AUDIT SCENE ---------- */
+
+.run-line { position: absolute; width: 1px; background: var(--piedra-700); }
+.run-dot {
+  position: absolute; width: 13px; height: 13px; border-radius: 50%;
+  border: 2px solid var(--piedra-950); z-index: 2;
+}
+.run-dot--ok { background: #4ade80; }
+.run-dot--fail { background: var(--lava-500); }
+.run-row {
+  position: absolute; width: 300px; display: flex; align-items: baseline; gap: .75rem;
+  font-family: ui-monospace, 'SF Mono', Consolas, monospace; font-size: .9375rem;
+}
+.run-row__name { color: var(--arena-200); }
+.run-row__meta { margin-left: auto; font-size: .8125rem; color: var(--arena-500); }
+.run-row--fail .run-row__meta { color: var(--lava-400); }
+
+
+/* Start sentinel, cloned from the flow editor (FlowCanvas.vue) */
+.scene__start { position: absolute; z-index: 2; }
+.scene__start-card {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px; border-radius: 12px;
+  background: rgba(26,26,29,.95);
+  border: 1px solid rgba(251,113,133,.35);
+  box-shadow: 0 8px 24px -10px rgba(0,0,0,.6);
+}
+.scene__start-ic {
+  width: 24px; height: 24px; border-radius: 7px;
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+  background: rgba(251,113,133,.15); color: #fb7185;
+}
+.scene__start-ic svg { width: 14px; height: 14px; }
+.scene__start-label {
+  font-size: 9px; font-weight: 700; letter-spacing: .08em;
+  text-transform: uppercase; color: #fb7185;
+}
+.scene__start-port {
+  position: absolute; right: -7px; top: 50%; transform: translateY(-50%);
+  width: 12px; height: 12px; border-radius: 9999px;
+  background: var(--piedra-700); border: 2px solid #fb7185;
+}

--- a/website/themes/magec/static/js/main.js
+++ b/website/themes/magec/static/js/main.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Centella } from './centella.js';
+import { initScenes } from './scenes.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   // Nav scroll
@@ -19,6 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // Hero orb
   const canvas = document.getElementById('hero-orb');
   if (canvas) new Centella(canvas).start();
+
+  // Scroll-driven feature scenes
+  initScenes();
 
   // Scroll reveal
   const obs = new IntersectionObserver(entries => {

--- a/website/themes/magec/static/js/scenes.js
+++ b/website/themes/magec/static/js/scenes.js
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Scroll-driven feature scenes. Each [data-scene] section is a tall block with
+// a sticky viewport inside; the scroll progress through the section drives
+// SVG wire drawing ([data-wire="start,end"]), element reveals
+// ([data-step="at"]) and pulses travelling along paths ([data-travel]).
+//
+// Lazy-viewer fallback: once a scene's sticky viewport is engaged, an
+// internal clock also advances its progress (AUTOPLAY_MS for the full
+// story). Whichever is further ahead, scroll or clock, wins.
+//
+// Dead-scroll skip: once a scene is fully played, wheeling down jumps
+// straight to the next scene instead of grinding through the leftover
+// scroll budget (and wheeling up jumps back to the scene start).
+// Clicking the bobbing hint ball also advances to the next scene.
+// No libraries: one rAF, passive listeners except the wheel hijack.
+
+const AUTOPLAY_MS = 6000;
+const DONE_AT = 0.85;
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const seg = (p, a, b) => clamp((p - a) / (b - a), 0, 1);
+const ease = t => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2);
+
+export function initScenes() {
+  const sections = [...document.querySelectorAll('[data-scene]')];
+  if (!sections.length) return;
+
+  const scenes = sections.map(scene => {
+    const wires = [...scene.querySelectorAll('[data-wire]')].map(path => {
+      // Faint ghost of the full route: hints that the circuit is incomplete
+      // and invites scrolling to draw it.
+      const ghost = path.cloneNode();
+      ghost.removeAttribute('data-wire');
+      ghost.classList.add('wire-ghost');
+      path.parentNode.insertBefore(ghost, path);
+
+      const len = path.getTotalLength();
+      path.style.strokeDasharray = `${len}`;
+      path.style.strokeDashoffset = `${len}`;
+      const [a, b] = path.dataset.wire.split(',').map(Number);
+      return { path, len, a, b };
+    });
+    const steps = [...scene.querySelectorAll('[data-step]')].map(el => ({
+      el,
+      at: Number(el.dataset.step),
+    }));
+    const travellers = [...scene.querySelectorAll('[data-travel]')].map(el => {
+      const [id, a, b] = el.dataset.travel.split(',');
+      const path = scene.querySelector(`#${id}`);
+      return { el, path, len: path.getTotalLength(), a: Number(a), b: Number(b) };
+    });
+    return { scene, wires, steps, travellers, auto: 0, done: false };
+  });
+
+  const finish = ({ scene, wires, steps, travellers }) => {
+    wires.forEach(w => { w.path.style.strokeDashoffset = '0'; });
+    steps.forEach(s => s.el.classList.add('on'));
+    travellers.forEach(t => { t.el.style.opacity = '0'; });
+    scene.classList.add('scene--done', 'scene--started');
+  };
+
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    scenes.forEach(finish);
+    return;
+  }
+
+  let rafId = 0;
+  let lastT = 0;
+  let jumping = false;
+
+  const render = (now) => {
+    rafId = 0;
+    const dt = lastT ? Math.min(now - lastT, 100) : 0;
+    lastT = now;
+    const vh = innerHeight;
+    let animating = false;
+
+    scenes.forEach(sc => {
+      const { scene, wires, steps, travellers } = sc;
+      const rect = scene.getBoundingClientRect();
+      if (rect.bottom < 0 || rect.top > vh) {
+        if (rect.top > vh) { sc.auto = 0; sc.done = false; } // below viewport: rearm
+        return;
+      }
+      const total = rect.height - vh;
+      const scrollP = total > 0 ? clamp(-rect.top / total, 0, 1) : 1;
+
+      // Sticky engaged: the clock starts ticking for lazy viewers.
+      if (rect.top <= 1 && sc.auto < 1) {
+        sc.auto = clamp(sc.auto + dt / AUTOPLAY_MS, 0, 1);
+        if (sc.auto < 1) animating = true;
+      }
+      const p = Math.max(scrollP, sc.auto);
+      sc.done = p >= DONE_AT;
+
+      wires.forEach(w => {
+        w.path.style.strokeDashoffset = `${w.len * (1 - ease(seg(p, w.a, w.b)))}`;
+      });
+      travellers.forEach(t => {
+        const tp = seg(p, t.a, t.b);
+        const active = tp > 0 && tp < 1;
+        t.el.style.opacity = active ? '1' : '0';
+        if (active) {
+          const pt = t.path.getPointAtLength(t.len * tp);
+          t.el.style.transform = `translate(${pt.x}px, ${pt.y}px)`;
+        }
+      });
+      steps.forEach(s => s.el.classList.toggle('on', p >= s.at));
+      scene.classList.toggle('scene--started', p > 0.04);
+      scene.classList.toggle('scene--done', sc.done);
+    });
+
+    if (animating) schedule();
+  };
+
+  const schedule = () => {
+    if (!rafId) rafId = requestAnimationFrame(render);
+  };
+
+  const jumpTo = (top) => {
+    jumping = true;
+    scrollTo({ top, behavior: 'smooth' });
+    setTimeout(() => { jumping = false; }, 700);
+  };
+
+  // The scroll offset where a scene's sticky releases (= end of its budget).
+  const sceneExit = sc => sc.scene.offsetTop + sc.scene.offsetHeight - innerHeight;
+
+  // Landing spot for "next": the next scene's own top, where its sticky is
+  // already engaged and the autoplay clock starts on its own. sceneExit would
+  // land one viewport too early (next scene still below the fold).
+  const nextSceneTop = sc => {
+    const i = scenes.indexOf(sc);
+    const next = scenes[i + 1];
+    return next ? next.scene.offsetTop + 2 : sceneExit(sc);
+  };
+
+  // Wheel hijack: skip dead scroll once the story has been told.
+  addEventListener('wheel', e => {
+    if (jumping) { e.preventDefault(); return; }
+    const vh = innerHeight;
+    const sc = scenes.find(s => {
+      const r = s.scene.getBoundingClientRect();
+      return r.top <= 0 && r.bottom >= vh;
+    });
+    if (!sc || !sc.done) return;
+    if (e.deltaY > 0) {
+      const remaining = sceneExit(sc) - scrollY;
+      if (remaining > 40) {
+        e.preventDefault();
+        jumpTo(nextSceneTop(sc));
+      }
+    } else if (e.deltaY < 0) {
+      const back = scrollY - sc.scene.offsetTop;
+      if (back > 40) {
+        e.preventDefault();
+        jumpTo(sc.scene.offsetTop + 2);
+      }
+    }
+  }, { passive: false });
+
+  // Hint ball click: advance to the next scene in one go.
+  scenes.forEach(sc => {
+    const hint = sc.scene.querySelector('.scene__hint');
+    if (hint) hint.addEventListener('click', () => jumpTo(nextSceneTop(sc)));
+  });
+
+  addEventListener('scroll', schedule, { passive: true });
+  addEventListener('resize', schedule, { passive: true });
+  schedule();
+}


### PR DESCRIPTION
Rewrote the landing page. The hero stays, everything below it is new: instead of the old sections with feature cards and text, now there's a tour of animated scenes that build up each part of Magec as you scroll (agents, mcps and skills, memory, flows, clients, voice, secrets, runs). The scenes use the same node cards and colors as the flow editor, so what you see in the landing is what you get in the app.

Each scene also plays by itself if you just sit there, and when it's done the scroll jumps you to the next one. The Magec ball at the bottom does the same on click. Nav menu is now Home / Tour / Docs, and the footer got cleaned up. No new dependencies.