### PR TITLE
Landing: fix scenes getting cut off at the bottom on phones

### DIFF
--- a/website/themes/magec/static/css/style.css
+++ b/website/themes/magec/static/css/style.css
@@ -690,7 +690,7 @@ section { padding: 6rem 0; }
    land with the sticky engaged (rect.top <= 1) so the autoplay clock starts. */
 .scene { scroll-margin-top: calc(-5rem - 2px); }
 .scene__sticky {
-  position: sticky; top: 0; height: 100vh;
+  position: sticky; top: 0; height: 100vh; height: 100dvh;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   overflow: hidden;
 }
@@ -706,10 +706,10 @@ section { padding: 6rem 0; }
 }
 .scene__desc { font-size: 1.0625rem; color: var(--arena-400); line-height: 1.7; }
 
-.scene__fit {
-  transform: scale(min(1, calc((100vw - 2rem) / 1040)));
-  transform-origin: top center;
-}
+/* Scale is computed by scenes.js (fitStages): CSS scale() cannot divide
+   lengths into the number it needs, so a stylesheet-only fit is not
+   expressible. JS measures the visible stage against the sticky viewport. */
+.scene__fit { transform-origin: top center; }
 .scene__stage { position: relative; width: 1040px; height: 560px; }
 
 .scene__wires { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
@@ -967,9 +967,6 @@ section { padding: 6rem 0; }
   .scene { height: 220vh; }
   .scene__head { margin-bottom: 1rem; padding: 0 1.25rem; }
   .scene__desc { font-size: .9375rem; }
-  .scene__fit {
-    transform: scale(min(1, calc((100vw - 1.5rem) / 360), calc((100vh - 250px) / var(--mh, 640))));
-  }
   .scene__stage { display: none; }
   .scene__stage--mobile { display: block; width: 360px; }
   .scene__stage--mobile .mem-quote { font-size: .875rem; text-align: center; }

--- a/website/themes/magec/static/js/scenes.js
+++ b/website/themes/magec/static/js/scenes.js
@@ -63,6 +63,7 @@ export function initScenes() {
 
   if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
     scenes.forEach(finish);
+    fitStages(sections);
     return;
   }
 
@@ -168,6 +169,34 @@ export function initScenes() {
   });
 
   addEventListener('scroll', schedule, { passive: true });
-  addEventListener('resize', schedule, { passive: true });
+  addEventListener('resize', () => { fitStages(sections); schedule(); }, { passive: true });
+  fitStages(sections);
   schedule();
+}
+
+// Scale each scene's visible stage so it fits the sticky viewport next to
+// its header, both in width and height. Done in JS because CSS scale()
+// needs a plain number and calc() cannot turn viewport/stage lengths into
+// one; the previous stylesheet-only attempt was silently invalid, which
+// left tall stages clipped at the bottom on phones.
+function fitStages(sections) {
+  sections.forEach(scene => {
+    const sticky = scene.querySelector('.scene__sticky');
+    const head = scene.querySelector('.scene__head');
+    const fit = scene.querySelector('.scene__fit');
+    if (!sticky || !fit) return;
+    const stage = [...fit.children].find(el => el.offsetParent !== null);
+    if (!stage) return;
+    const sw = stage.offsetWidth;
+    const sh = stage.offsetHeight;
+    const headH = head ? head.offsetHeight + 16 : 0;
+    const availW = sticky.clientWidth - 24;
+    const availH = sticky.clientHeight - headH - 88; // hint + breathing room
+    const scale = Math.min(1, availW / sw, availH / sh);
+    fit.style.transform = scale < 1 ? `scale(${scale})` : '';
+    // Only height needs collapsing: the flex column centers using layout
+    // boxes, and transform does not shrink them. Width stays natural so the
+    // top-center origin keeps the scaled stage horizontally centered.
+    fit.style.height = `${sh * scale}px`;
+  });
 }


### PR DESCRIPTION
The scenes were getting clipped at the bottom on phones. Turns out the CSS that was supposed to shrink each scene to fit the screen was invalid and browsers ignored it entirely, so tall scenes just overflowed and got cut.

The scaling is now done by the same script that drives the animations: it measures the scene against the visible screen and shrinks it so everything fits, header and scroll ball included. Also switched the scene viewport to the newer unit that accounts for the mobile browser's URL bar, which was eating part of the scene too.